### PR TITLE
fix race condition in mutex release

### DIFF
--- a/common/source/kernel/Mutex.cpp
+++ b/common/source/kernel/Mutex.cpp
@@ -95,8 +95,8 @@ void Mutex::release(const char* debug_info)
 {
   checkInvalidRelease("Mutex::release", debug_info);
   //kprintfd("Mutex::release %x %s, %s\n", this, name_, debug_info);
-  mutex_ = 0;
   held_by_=0;
+  mutex_ = 0;
   spinlock_.acquire();
   if ( ! sleepers_.empty() )
   {


### PR DESCRIPTION
setting mutex and held_by is not atomic.
if we get yielded twice in between that can result in failed assertions in the aquire/tryaquire methods

demo code that triggers the race:
https://github.com/plawatsch/sweb/tree/mutex-race-demo
