### PR TITLE
Gly warning cleanup

### DIFF
--- a/common/source/fs/VfsSyscall.cpp
+++ b/common/source/fs/VfsSyscall.cpp
@@ -101,11 +101,11 @@ int32 VfsSyscall::mkdir(const char* pathname, int32)
   sub_dentry->d_name_ = sub_dentry_name;
   debug(VFSSYSCALL, "(mkdir) creating Inode: current_dentry->getName(): %s\n", pw_dentry->getName());
   debug(VFSSYSCALL, "(mkdir) creating Inode: sub_dentry->getName(): %s\n", sub_dentry->getName());
-  debug(VFSSYSCALL, "(mkdir) current_sb: %d\n", current_sb);
-  debug(VFSSYSCALL, "(mkdir) current_sb->getFSType(): %d\n", current_sb->getFSType());
+  debug(VFSSYSCALL, "(mkdir) current_sb: %p\n", current_sb);
+  debug(VFSSYSCALL, "(mkdir) current_sb->getFSType(): %p\n", current_sb->getFSType());
 
   current_sb->createInode(sub_dentry, I_DIR);
-  debug(VFSSYSCALL, "(mkdir) sub_dentry->getInode(): %d\n", sub_dentry->getInode());
+  debug(VFSSYSCALL, "(mkdir) sub_dentry->getInode(): %p\n", sub_dentry->getInode());
   return 0;
 }
 
@@ -195,7 +195,7 @@ int32 VfsSyscall::rm(const char* pathname)
   }
   debug(VFSSYSCALL, "(rm) current_dentry->getName(): %s \n", pw_dentry->getName());
   Inode* current_inode = pw_dentry->getInode();
-  debug(VFSSYSCALL, "(rm) current_inode: %d\n", current_inode);
+  debug(VFSSYSCALL, "(rm) current_inode: %p\n", current_inode);
 
   if (current_inode->getType() != I_FILE)
   {
@@ -206,7 +206,7 @@ int32 VfsSyscall::rm(const char* pathname)
   Superblock* sb = current_inode->getSuperblock();
   if (current_inode->rm() == INODE_DEAD)
   {
-    debug(VFSSYSCALL, "remove the inode %d from the list of sb: %d\n", current_inode, sb);
+    debug(VFSSYSCALL, "remove the inode %p from the list of sb: %p\n", current_inode, sb);
     sb->delete_inode(current_inode);
     debug(VFSSYSCALL, "removed\n");
   }

--- a/common/source/fs/minixfs/MinixFSSuperblock.cpp
+++ b/common/source/fs/minixfs/MinixFSSuperblock.cpp
@@ -377,7 +377,7 @@ void MinixFSSuperblock::readBlocks(uint16 block, uint32 num_blocks, char* buffer
   assert(buffer);
 #ifdef EXE2MINIXFS
   fseek((FILE*)s_dev_, offset_ + block * BLOCK_SIZE, SEEK_SET);
-  (fread(buffer, 1, BLOCK_SIZE * num_blocks, (FILE*)s_dev_) == BLOCK_SIZE * num_blocks);
+  assert(fread(buffer, 1, BLOCK_SIZE * num_blocks, (FILE*)s_dev_) == BLOCK_SIZE * num_blocks);
 #else
   BDVirtualDevice* bdvd = BDManager::getInstance()->getDeviceByNumber(s_dev_);
   bdvd->readData(block * bdvd->getBlockSize(), num_blocks * bdvd->getBlockSize(), buffer);
@@ -393,7 +393,7 @@ void MinixFSSuperblock::writeBlocks(uint16 block, uint32 num_blocks, char* buffe
 {
 #ifdef EXE2MINIXFS
   fseek((FILE*)s_dev_, offset_ + block * BLOCK_SIZE, SEEK_SET);
-  (fwrite(buffer, 1, BLOCK_SIZE * num_blocks, (FILE*)s_dev_) == BLOCK_SIZE * num_blocks);
+  assert(fwrite(buffer, 1, BLOCK_SIZE * num_blocks, (FILE*)s_dev_) == BLOCK_SIZE * num_blocks);
 #else
   BDVirtualDevice* bdvd = BDManager::getInstance()->getDeviceByNumber(s_dev_);
   bdvd->writeData(block * bdvd->getBlockSize(), num_blocks * bdvd->getBlockSize(), buffer);

--- a/common/source/fs/minixfs/MinixStorageManager.cpp
+++ b/common/source/fs/minixfs/MinixStorageManager.cpp
@@ -69,7 +69,7 @@ size_t MinixStorageManager::allocZone()
     {
       zone_bitmap_.setBit(pos);
       curr_zone_pos_ = pos;
-      debug(M_STORAGE_MANAGER, "acquireZone: Zone %lld acquired\n", pos);
+      debug(M_STORAGE_MANAGER, "acquireZone: Zone %lld acquired\n", (unsigned long long) pos);
       return pos;
     }
   }
@@ -89,7 +89,7 @@ size_t MinixStorageManager::allocInode()
     {
       inode_bitmap_.setBit(pos);
       curr_inode_pos_ = pos;
-      debug(M_STORAGE_MANAGER, "acquireInode: Inode %lld acquired\n", pos);
+      debug(M_STORAGE_MANAGER, "acquireInode: Inode %lld acquired\n", (unsigned long long) pos);
       return pos;
     }
   }
@@ -101,13 +101,13 @@ size_t MinixStorageManager::allocInode()
 void MinixStorageManager::freeZone(size_t index)
 {
   zone_bitmap_.unsetBit(index);
-  debug(M_STORAGE_MANAGER, "freeZone: Zone %lld freed\n", index);
+  debug(M_STORAGE_MANAGER, "freeZone: Zone %lld freed\n", (unsigned long long) index);
 }
 
 void MinixStorageManager::freeInode(size_t index)
 {
   inode_bitmap_.unsetBit(index);
-  debug(M_STORAGE_MANAGER, "freeInode: Inode %lld freed\n", index);
+  debug(M_STORAGE_MANAGER, "freeInode: Inode %lld freed\n", (unsigned long long) index);
 }
 
 void MinixStorageManager::flush(MinixFSSuperblock *superblock)

--- a/common/source/fs/minixfs/MinixStorageManager.cpp
+++ b/common/source/fs/minixfs/MinixStorageManager.cpp
@@ -69,7 +69,7 @@ size_t MinixStorageManager::allocZone()
     {
       zone_bitmap_.setBit(pos);
       curr_zone_pos_ = pos;
-      debug(M_STORAGE_MANAGER, "acquireZone: Zone %lld acquired\n", (unsigned long long) pos);
+      debug(M_STORAGE_MANAGER, "acquireZone: Zone %zu acquired\n", pos);
       return pos;
     }
   }
@@ -89,7 +89,7 @@ size_t MinixStorageManager::allocInode()
     {
       inode_bitmap_.setBit(pos);
       curr_inode_pos_ = pos;
-      debug(M_STORAGE_MANAGER, "acquireInode: Inode %lld acquired\n", (unsigned long long) pos);
+      debug(M_STORAGE_MANAGER, "acquireInode: Inode %zu acquired\n", pos);
       return pos;
     }
   }
@@ -101,13 +101,13 @@ size_t MinixStorageManager::allocInode()
 void MinixStorageManager::freeZone(size_t index)
 {
   zone_bitmap_.unsetBit(index);
-  debug(M_STORAGE_MANAGER, "freeZone: Zone %lld freed\n", (unsigned long long) index);
+  debug(M_STORAGE_MANAGER, "freeZone: Zone %zu freed\n", index);
 }
 
 void MinixStorageManager::freeInode(size_t index)
 {
   inode_bitmap_.unsetBit(index);
-  debug(M_STORAGE_MANAGER, "freeInode: Inode %lld freed\n", (unsigned long long) index);
+  debug(M_STORAGE_MANAGER, "freeInode: Inode %zu freed\n", index);
 }
 
 void MinixStorageManager::flush(MinixFSSuperblock *superblock)


### PR DESCRIPTION
Please check if this compiles on Windows before merging.

I assume that the asserts have been forgotten after converting from read() to fread() in 93642d9. However, I might be wrong and they were omitted on purpose.

If this is the case the result of the comparison is never used.

(excuse me for sending the PR twice, but I was told always to base on master, not to incorporate changes from another PR of mine in a second one)