### PR TITLE
Make Thread::kill virtual to fix bug.

### DIFF
--- a/common/include/kernel/Thread.h
+++ b/common/include/kernel/Thread.h
@@ -45,7 +45,7 @@ class Thread
      * Marks the thread to be deleted by the scheduler.
      * DO Not use new / delete in this Method, as it sometimes called from an Interrupt Handler with Interrupts disabled
      */
-    void kill();
+    virtual void kill();
 
     /**
      * runs whatever the user wants it to run;


### PR DESCRIPTION
CleanupThread implements kill to fire an assertion.
This kill version was not called by the page fault handler since kill in
the parent class was not virtual.