### PR TITLE
Fix: ARM memory calculation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(POLICY CMP0037)
 endif(POLICY CMP0037)
 
 if ("${ARCH}" STREQUAL "")
-  set (ARCH "x86/32")
+  set (ARCH "arm/integratorcp")
 endif("${ARCH}" STREQUAL "")
 MESSAGE("-- Target architecture: ${ARCH}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(POLICY CMP0037)
 endif(POLICY CMP0037)
 
 if ("${ARCH}" STREQUAL "")
-  set (ARCH "arm/integratorcp")
+  set (ARCH "x86/32")
 endif("${ARCH}" STREQUAL "")
 MESSAGE("-- Target architecture: ${ARCH}")
 

--- a/arch/arm/common/source/ArchMemory.cpp
+++ b/arch/arm/common/source/ArchMemory.cpp
@@ -173,7 +173,7 @@ pointer ArchMemory::checkAddressValid(uint32 vaddress_to_check)
     PageTableEntry *pte_base = ((PageTableEntry *) getIdentAddressOfPPN(page_directory[pde_vpn].pt.pt_ppn - PHYS_OFFSET_4K)) + page_directory[pde_vpn].pt.offset * PAGE_TABLE_ENTRIES;
     if (pte_base[pte_vpn].size == 2)
     {
-      return getIdentAddressOfPPN(pte_base[pte_vpn].page_ppn,PDE_SIZE_PT) | (vaddress_to_check % PDE_SIZE_PAGE);
+      return getIdentAddressOfPPN(pte_base[pte_vpn].page_ppn) | (vaddress_to_check % PAGE_SIZE);
     }
   }
   return 0;

--- a/arch/arm/common/source/ArchMemory.cpp
+++ b/arch/arm/common/source/ArchMemory.cpp
@@ -166,7 +166,7 @@ pointer ArchMemory::checkAddressValid(uint32 vaddress_to_check)
   uint32 pte_vpn = virtual_page % PAGE_TABLE_ENTRIES;
   if (page_directory[pde_vpn].pt.size == PDE_SIZE_PAGE)
   {
-    return getIdentAddressOfPPN(page_directory[pde_vpn].page.page_ppn,PDE_SIZE_PAGE) | (vaddress_to_check % PDE_SIZE_PAGE);
+    return getIdentAddressOfPPN(page_directory[pde_vpn].page.page_ppn,PAGE_SIZE * PAGE_TABLE_ENTRIES) | (vaddress_to_check % (PAGE_SIZE * PAGE_TABLE_ENTRIES));
   }
   else if (page_directory[pde_vpn].pt.size == PDE_SIZE_PT)
   {


### PR DESCRIPTION
The address calculation of ArchMemory::checkAddressValid() provided a wrong ident address.