### PR TITLE
x86_64: Fix large executable files.

### DIFF
--- a/arch/x86/64/CMakeLists.userspace
+++ b/arch/x86/64/CMakeLists.userspace
@@ -1,2 +1,2 @@
 set(CMAKE_C_FLAGS "-Wall -std=gnu11 -g -O0 -m64 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common")
-set(CMAKE_C_LINK_FLAGS "")
+set(CMAKE_C_LINK_FLAGS "-Wl,-z,max-page-size=0x1000")


### PR DESCRIPTION
Set ld's max page size to 4KB to prevent it from aligning each section
to a 2MB page boundary, making each executable at least 2MB large.

Fixed together with Daniel Kales.