### PR TITLE
fixed strncmp bug + gitignore for Clion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ utils/bochs/bochsrc
 .cdtbuild
 *.DS_Store
 *Thumbs.db
+.idea

--- a/common/source/util/kstring.cpp
+++ b/common/source/util/kstring.cpp
@@ -305,7 +305,7 @@ extern "C" int32 strcmp(const char *str1, const char *str2)
 
 extern "C" int32 strncmp(const char *str1, const char *str2, size_t n)
 {
-  while (n-- && (*str1) && (*str2))
+  while (n && (*str1) && (*str2))
   {
     if (*str1 != *str2)
     {
@@ -313,6 +313,7 @@ extern "C" int32 strncmp(const char *str1, const char *str2, size_t n)
     }
     ++str1;
     ++str2;
+    --n;
   }
   if (n == 0)
     return 0;

--- a/common/source/util/kstring.cpp
+++ b/common/source/util/kstring.cpp
@@ -314,8 +314,10 @@ extern "C" int32 strncmp(const char *str1, const char *str2, size_t n)
     ++str1;
     ++str2;
   }
-
-  return (*(uint8 *) str1 - *(uint8 *) str2);
+  if (n == 0)
+    return 0;
+  else
+    return (*(uint8 *) str1 - *(uint8 *) str2);
 }
 
 extern "C" int32 bcmp(const void *region1, const void *region2, size_t size)


### PR DESCRIPTION
as discussed in #74, implemented a fix for strncmp

also included is a .gitignore entry for the Clion project folder,
since more and more students are using it instead of Eclipse