### PR TITLE
Added DeviceFSSuperblock::removeFd(...)

### DIFF
--- a/common/include/fs/devicefs/DeviceFSSuperblock.h
+++ b/common/include/fs/devicefs/DeviceFSSuperblock.h
@@ -41,6 +41,14 @@ class DeviceFSSuperBlock : public Superblock
     virtual int32 createFd(Inode* inode, uint32 flag);
 
     /**
+     * remove the corresponding file descriptor.
+     * @param inode the inode from which to remove the fd from
+     * @param fd the fd to remove
+     * @return 0 on success
+     */
+    virtual int32 removeFd(Inode* inode, FileDescriptor* fd);
+
+    /**
      * addsa new device to the superblock
      * @param inode the inode of the device to add
      * @param device_name the device name

--- a/common/source/fs/devicefs/DeviceFSSuperblock.cpp
+++ b/common/source/fs/devicefs/DeviceFSSuperblock.cpp
@@ -122,3 +122,25 @@ int32 DeviceFSSuperBlock::createFd(Inode* inode, uint32 flag)
 
   return (fd->getFd());
 }
+
+
+int32 DeviceFSSuperBlock::removeFd(Inode* inode, FileDescriptor* fd)
+{
+  assert(inode);
+  assert(fd);
+
+  s_files_.remove(fd);
+  FileDescriptor::remove(fd);
+
+  File* file = fd->getFile();
+  int32 tmp = inode->unlink(file);
+
+  debug(RAMFS, "remove the fd num: %d\n", fd->getFd());
+  if (inode->getNumOpenedFile() == 0)
+  {
+    used_inodes_.remove(inode);
+  }
+  delete fd;
+
+  return tmp;
+}


### PR DESCRIPTION
This fixes a bug where it wasn't possible to delete a file (VfsSyscall::rm(...)), which was previously created by VfsSyscall::open(...).

The problem was that when calling VfsSyscall::close, the default implementation of removeFd of the Superblock base-class was invoked. Because of that, the entry in the list of open files in the RamFSInode wasn't cleared - which subsequently led to the failure of VfsSyscall::rm(...), because the list was not empty.

Steps to reproduce the bug:
- Create file somewhere within devicefs (e.g. /foo.txt) using VfsSyscall::open
- Close the file descriptor using VfsSyscall::close
- Remove the file using VfsSyscall::rm --> this fails