### PR TITLE
Beaviour of kprintf

### DIFF
--- a/common/include/console/Terminal.h
+++ b/common/include/console/Terminal.h
@@ -113,11 +113,6 @@ class Terminal : public CharacterDevice
 
     void setLayout(Terminal::LAYOUTS layout);
 
-    bool isLockFree()
-    {
-      return mutex_.isFree();
-    }
-
   protected:
 
     void setAsActiveTerminal();

--- a/common/source/console/kprintf.cpp
+++ b/common/source/console/kprintf.cpp
@@ -58,9 +58,14 @@ void kprintf_func(int ch, void *arg __attribute__((unused)))
 {
   //check if atomar or not in current context
   if ((ArchInterrupts::testIFSet() && Scheduler::instance()->isSchedulingEnabled())
-      || (main_console->areLocksFree() && main_console->getActiveTerminal()->isLockFree()))
+      || (main_console->areLocksFree() &&
+          ((currentThread && currentThread->getTerminal()->isLockFree()) ||
+           main_console->getActiveTerminal()->isLockFree())))
   {
-    main_console->getActiveTerminal()->write(ch);
+    if(currentThread)
+      currentThread->getTerminal()->write(ch);
+    else
+      main_console->getActiveTerminal()->write(ch);
   }
   else
   {

--- a/common/source/console/kprintf.cpp
+++ b/common/source/console/kprintf.cpp
@@ -57,12 +57,13 @@ void kprintf_init()
 void kprintf_func(int ch, void *arg __attribute__((unused)))
 {
   //check if atomar or not in current context
+  bool active_free = main_console->getActiveTerminal()->isLockFree();
+  bool current_free = currentThread && currentThread->getTerminal()->isLockFree();
+
   if ((ArchInterrupts::testIFSet() && Scheduler::instance()->isSchedulingEnabled())
-      || (main_console->areLocksFree() &&
-          ((currentThread && currentThread->getTerminal()->isLockFree()) ||
-           main_console->getActiveTerminal()->isLockFree())))
+      || (main_console->areLocksFree() && (active_free || current_free)))
   {
-    if(currentThread)
+    if(current_free)
       currentThread->getTerminal()->write(ch);
     else
       main_console->getActiveTerminal()->write(ch);

--- a/common/source/console/kprintf.cpp
+++ b/common/source/console/kprintf.cpp
@@ -57,13 +57,10 @@ void kprintf_init()
 void kprintf_func(int ch, void *arg __attribute__((unused)))
 {
   //check if atomar or not in current context
-  bool active_free = main_console->getActiveTerminal()->isLockFree();
-  bool current_free = currentThread && currentThread->getTerminal()->isLockFree();
-
   if ((ArchInterrupts::testIFSet() && Scheduler::instance()->isSchedulingEnabled())
-      || (main_console->areLocksFree() && (active_free || current_free)))
+      || main_console->areLocksFree())
   {
-    if(current_free)
+    if(currentThread)
       currentThread->getTerminal()->write(ch);
     else
       main_console->getActiveTerminal()->write(ch);


### PR DESCRIPTION
I made some changes that allow threads to really use their given terminal, instead of only printing to the active one. The method isLockFree() seems redundant here. Note that getTerminal() still defaults to the active one if no other terminal is given to the thread.