### PR TITLE
x86_64: Enable floating point arithmetic

### DIFF
--- a/arch/x86/64/source/ArchThreads.cpp
+++ b/arch/x86/64/source/ArchThreads.cpp
@@ -13,6 +13,14 @@ void ArchThreads::initialise()
 {
   currentThreadRegisters = (ArchThreadRegisters*) new uint8[sizeof(ArchThreadRegisters)];
 
+  /** Enable SSE for floating point instructions in long mode **/
+  asm volatile ("movq %cr0, %rax\n"
+          "and $0xFFFB, %ax\n"
+          "or $0x2, %ax\n"
+          "movq %rax, %cr0\n"
+          "movq %cr4, %rax\n"
+          "orq $0x200, %rax\n"
+          "movq %rax, %cr4\n");
 }
 void ArchThreads::setAddressSpace(Thread *thread, ArchMemory& arch_memory)
 {


### PR DESCRIPTION
Currently sweb stops with a general protection fault when a userspace program attempts to use floating point instructions in long mode.

The reason for that is that gcc uses the SSE instructions set extension when compiling for x86_64, whereas for x86_32 the traditional FPU instructions are used.

This patch fixes the problem by enabling SSE at boot time.
I tested it with my sleep und usleep syscalls (these syscalls require floating point arithmetic in userspace), they work perfectly accurately after applying this patch.
