### PR TITLE
Fixed backtrace bug, made debugging of unwanted kernel pagefaults easier

### DIFF
--- a/arch/x86/32/common/source/InterruptUtils.cpp
+++ b/arch/x86/32/common/source/InterruptUtils.cpp
@@ -281,8 +281,7 @@ extern "C" void pageFaultHandler(uint32 address, uint32 error)
           address, address > 2U * 1024U * 1024U * 1024U ? "kernel" : "user", currentThread->getName(),
           currentThread, currentThread->user_registers_ ? "user" : "kernel");
 
-    if (!user_pagefault)
-      currentThread->printBacktrace(true);
+    currentThread->printBacktrace(true);
 
     if (currentThread->loader_)
       Syscall::exit(9999);

--- a/arch/x86/32/common/source/InterruptUtils.cpp
+++ b/arch/x86/32/common/source/InterruptUtils.cpp
@@ -269,6 +269,9 @@ extern "C" void pageFaultHandler(uint32 address, uint32 error)
   //lets hope this Exeption wasn't thrown during a TaskSwitch
   if (!page_present && address < 2U * 1024U * 1024U * 1024U && currentThread->loader_)
   {
+    if (!user_pagefault && address < PAGE_SIZE)
+      currentThread->printBacktrace(true);
+
     currentThread->loader_->loadPage(address);
   }
   else
@@ -278,7 +281,7 @@ extern "C" void pageFaultHandler(uint32 address, uint32 error)
           address, address > 2U * 1024U * 1024U * 1024U ? "kernel" : "user", currentThread->getName(),
           currentThread, currentThread->user_registers_ ? "user" : "kernel");
 
-    if(user_pagefault)
+    if (!user_pagefault)
       currentThread->printBacktrace(true);
 
     if (currentThread->loader_)

--- a/arch/x86/64/source/InterruptUtils.cpp
+++ b/arch/x86/64/source/InterruptUtils.cpp
@@ -294,8 +294,7 @@ extern "C" void pageFaultHandler(uint64 address, uint64 error)
     debug(PAGEFAULT, "!(error & FLAG_PF_PRESENT): %x, address: %x, loader_: %p\n",
         !(error & FLAG_PF_PRESENT), address < 0xFFFFFFFF00000000ULL, currentThread->loader_);
 
-    if (!(error & FLAG_PF_USER))
-      currentThread->printBacktrace(true);
+    currentThread->printBacktrace(true);
 
     if (currentThread->loader_)
       Syscall::exit(9999);

--- a/arch/x86/64/source/InterruptUtils.cpp
+++ b/arch/x86/64/source/InterruptUtils.cpp
@@ -284,6 +284,9 @@ extern "C" void pageFaultHandler(uint64 address, uint64 error)
   //lets hope this Exeption wasn't thrown during a TaskSwitch
   if (! (error & FLAG_PF_PRESENT) && address < 0xFFFFFFFF00000000ULL && currentThread->loader_)
   {
+    if (!(error & FLAG_PF_USER) && address < PAGE_SIZE)
+      currentThread->printBacktrace(true);
+
     currentThread->loader_->loadPage(address); //load stuff
   }
   else


### PR DESCRIPTION
This patch changes two things:

Firstly, it fixes a suspected backtracing bug for x86_32. (wrong if-condition)

Secondly, it prints backtraces for zero page dereferences in kernel mode.
These can be a pain to debug since most of the time sweb crashes at an arbitrary point after killing the current thread or process.
Printing backtraces for this cases shows the root cause of the zero pagefault.

I did this for both x86_32 and x86_64, however it would be nice to have an architecture independent pagefaulthandler class, like we have for the syscall handler.