### PR TITLE
Replaced hardcoded address limits with arch dependent USER_BREAK constant

### DIFF
--- a/arch/arm/common/include/offsets.h
+++ b/arch/arm/common/include/offsets.h
@@ -37,3 +37,8 @@
  */
 #define VIRTUAL_TO_PHYSICAL_BOOT(x) ((x) - PHYSICAL_TO_VIRTUAL_OFFSET)
 
+/**
+ * Only addresses below 2gig virtual belong to the user space
+ */
+#define USER_BREAK LINK_BASE
+

--- a/arch/x86/32/common/include/offsets.h
+++ b/arch/x86/32/common/include/offsets.h
@@ -35,3 +35,8 @@
  */
 #define VIRTUAL_TO_PHYSICAL_BOOT(x) ((x) - PHYSICAL_TO_VIRTUAL_OFFSET)
 
+/**
+ * Only addresses below 2gig virtual belong to the user space
+ */
+#define USER_BREAK LINK_BASE
+

--- a/arch/x86/32/common/source/InterruptUtils.cpp
+++ b/arch/x86/32/common/source/InterruptUtils.cpp
@@ -18,6 +18,7 @@
 #include "Loader.h"
 #include "Syscall.h"
 #include "paging-definitions.h"
+#include "offsets.h"
 
 #define LO_WORD(x) (((uint32)(x)) & 0x0000FFFF)
 #define HI_WORD(x) ((((uint32)(x)) >> 16) & 0x0000FFFF)
@@ -267,7 +268,7 @@ extern "C" void pageFaultHandler(uint32 address, uint32 error)
   const bool page_present = (error & FLAG_PF_PRESENT);
   const bool user_pagefault = (error & FLAG_PF_USER);
   //lets hope this Exeption wasn't thrown during a TaskSwitch
-  if (!page_present && address < 2U * 1024U * 1024U * 1024U && currentThread->loader_)
+  if (!page_present && address < USER_BREAK && currentThread->loader_)
   {
     if (!user_pagefault && address < PAGE_SIZE)
       currentThread->printBacktrace(true);
@@ -278,7 +279,7 @@ extern "C" void pageFaultHandler(uint32 address, uint32 error)
   {
     debug(PAGEFAULT, "ERROR: The virtual page of address %x (%s-address) is present,"
           "the pagefault was triggered by thread %s(%p), which is a %s""thread.\n",
-          address, address > 2U * 1024U * 1024U * 1024U ? "kernel" : "user", currentThread->getName(),
+          address, address > USER_BREAK ? "kernel" : "user", currentThread->getName(),
           currentThread, currentThread->user_registers_ ? "user" : "kernel");
 
     currentThread->printBacktrace(true);

--- a/arch/x86/64/include/offsets.h
+++ b/arch/x86/64/include/offsets.h
@@ -22,3 +22,7 @@
  */
 #define VIRTUAL_TO_PHYSICAL_BOOT(x) ((void*)(~PHYSICAL_TO_VIRTUAL_OFFSET & ((uint64)x)))
 
+/**
+ * Use only the lower canonical half for userspace
+ */
+#define USER_BREAK 0x0000800000000000ULL

--- a/common/source/kernel/Syscall.cpp
+++ b/common/source/kernel/Syscall.cpp
@@ -1,11 +1,7 @@
+#include "offsets.h"
 #include "Syscall.h"
 #include "syscall-definitions.h"
-#include "assert.h"
-#include "kprintf.h"
-#include "ArchCommon.h"
-#include "ArchInterrupts.h"
 #include "Terminal.h"
-#include "debug.h"
 #include "debug_bochs.h"
 #include "VfsSyscall.h"
 #include "UserProcess.h"
@@ -67,7 +63,7 @@ void Syscall::exit(size_t exit_code)
 size_t Syscall::write(size_t fd, pointer buffer, size_t size)
 {
   //WARNING: this might fail if Kernel PageFaults are not handled
-  if ((buffer >= 2U * 1024U * 1024U * 1024U) || (buffer + size > 2U * 1024U * 1024U * 1024U))
+  if ((buffer >= USER_BREAK) || (buffer + size > USER_BREAK))
   {
     return -1U;
   }
@@ -85,7 +81,7 @@ size_t Syscall::write(size_t fd, pointer buffer, size_t size)
 
 size_t Syscall::read(size_t fd, pointer buffer, size_t count)
 {
-  if ((buffer >= 2U * 1024U * 1024U * 1024U) || (buffer + count > 2U * 1024U * 1024U * 1024U))
+  if ((buffer >= USER_BREAK) || (buffer + count > USER_BREAK))
   {
     return -1U;
   }
@@ -110,7 +106,7 @@ size_t Syscall::close(size_t fd)
 
 size_t Syscall::open(size_t path, size_t flags)
 {
-  if (path >= 2U * 1024U * 1024U * 1024U)
+  if (path >= USER_BREAK)
   {
     return -1U;
   }
@@ -120,7 +116,7 @@ size_t Syscall::open(size_t path, size_t flags)
 void Syscall::outline(size_t port, pointer text)
 {
   //WARNING: this might fail if Kernel PageFaults are not handled
-  if (text >= 2U * 1024U * 1024U * 1024U)
+  if (text >= USER_BREAK)
   {
     return;
   }
@@ -136,7 +132,7 @@ size_t Syscall::createprocess(size_t path, size_t sleep)
   // AVOID USING IT AS SOON AS YOU HAVE AN ALTERNATIVE!
 
   // parameter check begin
-  if (path >= 2U * 1024U * 1024U * 1024U)
+  if (path >= USER_BREAK)
   {
     return -1U;
   }


### PR DESCRIPTION
I think we should restrict the user space to the lower canonical half, since this allows a clear separation of kernel and user space pointers, similar to other kernels like Linux.

Therefore I set x86_64 USER_BREAK to 0x0000800000000000, the first invalid address above the lower canonical half.
