### PR TITLE
changed color codes to reset the color correctly to the default color

### DIFF
--- a/common/include/console/debug.h
+++ b/common/include/console/debug.h
@@ -16,7 +16,7 @@ enum AnsiColor
 #define OUTPUT_FLAGS (OUTPUT_ENABLED | OUTPUT_ADVANCED)
 
 #ifndef NOCOLOR
-#define DEBUG_FORMAT_STRING "\033[0;%zum[%-11s]\033[1;m"
+#define DEBUG_FORMAT_STRING "\033[1;%zum[%-11s]\033[0;39m"
 #define COLOR_PARAM(flag) (flag & ~OUTPUT_FLAGS), #flag
 #else
 #define DEBUG_FORMAT_STRING "[%-11s]"


### PR DESCRIPTION
this is needed for windows cmdline to reset the color after the tag

also made the tag (e.g [PAGEFAULT ]) bold and the text following it
normal (although that is up for discussion, I think it should be this way round)