### PR TITLE
Userspace assert

### DIFF
--- a/userspace/libc/include/assert.h
+++ b/userspace/libc/include/assert.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define assert(X) do { if (!(X)) {\
+    printf("Assertion  failed: '" #X "', file %s, function %s, line %d\n", __FILE__, __FUNCTION__, __LINE__); \
+ exit(-1); } } while (0)
+


### PR DESCRIPTION
Although I am not sure if we want this in baseline sweb, I think that it would encourage students to write better tests from the beginning on.

I have seen groups that wrote tons of printf()-statements in their tests instead of using assert, which made it impossible to run quick regression tests.
Therefore, having assert in baseline sweb might improve the implementation quality for a lot of groups.