### PR TITLE
Fix an array overrun on args if 10 arguments are passed

### DIFF
--- a/userspace/tests/shell.c
+++ b/userspace/tests/shell.c
@@ -27,10 +27,10 @@ void handle_command(char* buffer, int buffer_size)
 
   for (c = 0; c < buffer_size && buffer[c]; c++)
   {
-    if (argsCount > 10)
+    if (argsCount >= 10)
     {
       argsCount = 10;
-      printf("Argument Count is limited to 10 (no dynamic memory allocation) all other arguments will be ignores\n");
+      printf("Argument count is limited to 10 (no dynamic memory allocation) - all other arguments will be ignored\n");
       break;
     }
     if (buffer[c] == '\r' || buffer[c] == '\n' || buffer[c] == ' ')


### PR DESCRIPTION
As the title says - shell.c line 30 uses `argsCount > 10` as a condition for breaking out of the loop. For `argsCount == 10`, this does not trigger a break, leading to an out-of-bounds memcpy to `args[10]` in line 45.

Changing the check to `argsCount >= 10` solves the problem.