### PR TITLE
changed relevant datatypes to proper work with 64bit architecture

### DIFF
--- a/userspace/libc/include/pthread.h
+++ b/userspace/libc/include/pthread.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include "types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 //pthread typedefs
-typedef long unsigned int pthread_t;
+typedef size_t pthread_t;
 typedef unsigned int pthread_attr_t;
 
 //pthread mutex typedefs

--- a/userspace/libc/include/pthread.h
+++ b/userspace/libc/include/pthread.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 //pthread typedefs
-typedef unsigned int pthread_t;
+typedef long unsigned int pthread_t;
 typedef unsigned int pthread_attr_t;
 
 //pthread mutex typedefs

--- a/userspace/libc/include/wait.h
+++ b/userspace/libc/include/wait.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "types.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -9,7 +11,7 @@ extern "C" {
 //pid typedefs
 #ifndef PID_T_DEFINED
 #define PID_T_DEFINED
-typedef long int pid_t;
+typedef ssize_t pid_t;
 #endif // PID_T_DEFINED
 
 extern pid_t waitpid(pid_t pid, int *status, int options);

--- a/userspace/libc/include/wait.h
+++ b/userspace/libc/include/wait.h
@@ -9,7 +9,7 @@ extern "C" {
 //pid typedefs
 #ifndef PID_T_DEFINED
 #define PID_T_DEFINED
-typedef int pid_t;
+typedef long int pid_t;
 #endif // PID_T_DEFINED
 
 extern pid_t waitpid(pid_t pid, int *status, int options);


### PR DESCRIPTION
I struggled the last few days with an immense strange bug. The For - Loop variable got reset every time i created a thread with a pthread_create() call inside. No wonder, I tried to put an unsigned long into an unsigned int and this caused an overflow. I want to keep you safe from that pain ! 