### PR TITLE
Added 64 bit support for userspace printf

### DIFF
--- a/userspace/libc/include/assert.h
+++ b/userspace/libc/include/assert.h
@@ -4,6 +4,6 @@
 #include <stdlib.h>
 
 #define assert(X) do { if (!(X)) {\
-    printf("Assertion  failed: '" #X "', file %s, function %s, line %d\n", __FILE__, __FUNCTION__, __LINE__); \
+    printf("Assertion failed: '" #X "', file %s, function %s, line %d\n", __FILE__, __FUNCTION__, __LINE__); \
  exit(-1); } } while (0)
 


### PR DESCRIPTION
I added 64 bit support using the `%z` prefix format specifier.
It works with signed and unsigned decimal integers (`%zd`, `%zu`), as well as with hexadecimal integers (`%zx`).

In addition I added support for the `%p` format specifier to make printing pointers more comfortable.

I changed as little code as possible and carried out tests on both `x86_64` and `x86_32` to make sure that nothing gets broken.

(Yet I am unsure whether we should merge this into devel or master, in order to avoid master-changes during the winter term. I also fixed a typo in `assert.h`)
