### PR TITLE
Fix for broadcast in condition

### DIFF
--- a/common/include/kernel/Condition.h
+++ b/common/include/kernel/Condition.h
@@ -49,8 +49,10 @@ class Condition : public Lock
      * If the list is empty, signal is being lost.
      * @param called_by A pointer to the call point of this function.
      *                  Can be set in case this method is called by a wrapper function.
+     * @param lock_waiters_list Lock the waiters list before accessing it.
+     *                  Must be set to false in case the waiters list is already locked in the calling function.
      */
-    void signal(pointer called_by = 0, bool locked_waiters_list = false);
+    void signal(pointer called_by = 0, bool lock_waiters_list = true);
 
     /**
      * Wakes up all Threads on the sleepers list.

--- a/common/include/kernel/Condition.h
+++ b/common/include/kernel/Condition.h
@@ -50,7 +50,7 @@ class Condition : public Lock
      * @param called_by A pointer to the call point of this function.
      *                  Can be set in case this method is called by a wrapper function.
      */
-    void signal(pointer called_by = 0);
+    void signal(pointer called_by = 0, bool locked_waiters_list = false);
 
     /**
      * Wakes up all Threads on the sleepers list.

--- a/common/source/kernel/Condition.cpp
+++ b/common/source/kernel/Condition.cpp
@@ -59,7 +59,7 @@ void Condition::wait(bool re_acquire_mutex, pointer called_by)
   }
 }
 
-void Condition::signal(pointer called_by)
+void Condition::signal(pointer called_by, bool locked_waiters_list)
 {
   if(unlikely(system_state != RUNNING))
     return;
@@ -72,10 +72,12 @@ void Condition::signal(pointer called_by)
 
   assert(mutex_->isHeldBy(currentThread));
   checkInterrupts("Condition::signal");
-  lockWaitersList();
+  if(!locked_waiters_list)
+    lockWaitersList();
   last_accessed_at_ = called_by;
   Thread* thread_to_be_woken_up = popBackThreadFromWaitersList();
-  unlockWaitersList();
+  if(!locked_waiters_list)
+    unlockWaitersList();
 
   if(thread_to_be_woken_up)
   {
@@ -107,8 +109,10 @@ void Condition::broadcast(pointer called_by)
     called_by = getCalledBefore(1);
   assert(mutex_->isHeldBy(currentThread));
   // signal em all
+  lockWaitersList();
   while(threadsAreOnWaitersList())
   {
-    signal(called_by);
+    signal(called_by, true);
   }
+  unlockWaitersList();
 }

--- a/common/source/kernel/Condition.cpp
+++ b/common/source/kernel/Condition.cpp
@@ -59,7 +59,7 @@ void Condition::wait(bool re_acquire_mutex, pointer called_by)
   }
 }
 
-void Condition::signal(pointer called_by, bool locked_waiters_list)
+void Condition::signal(pointer called_by, bool lock_waiters_list)
 {
   if(unlikely(system_state != RUNNING))
     return;
@@ -72,11 +72,11 @@ void Condition::signal(pointer called_by, bool locked_waiters_list)
 
   assert(mutex_->isHeldBy(currentThread));
   checkInterrupts("Condition::signal");
-  if(!locked_waiters_list)
+  if(lock_waiters_list)
     lockWaitersList();
   last_accessed_at_ = called_by;
   Thread* thread_to_be_woken_up = popBackThreadFromWaitersList();
-  if(!locked_waiters_list)
+  if(lock_waiters_list)
     unlockWaitersList();
 
   if(thread_to_be_woken_up)
@@ -112,7 +112,7 @@ void Condition::broadcast(pointer called_by)
   lockWaitersList();
   while(threadsAreOnWaitersList())
   {
-    signal(called_by, true);
+    signal(called_by, false);
   }
   unlockWaitersList();
 }


### PR DESCRIPTION
The problem was that in the wait function the mutex is released after locking the waiters list, so everything should still be locked but in the broadcast function the waiters list was not locked when checking for elements. 
In my case this produced a deadlock because the wait function was interrupted and while holding the waiters list lock but before adding the thread to the waiters list. Then the broadcast function was called, which checks for elements in the waiters list, since the waiters list was still empty and since it is not locked the thread was not woken up.
