### PR TITLE
Fix race condition in Thread::kill()

### DIFF
--- a/common/source/kernel/Thread.cpp
+++ b/common/source/kernel/Thread.cpp
@@ -57,14 +57,12 @@ Thread::~Thread()
   debug(THREAD, "~Thread: done (%s)\n", name_.c_str());
 }
 
-//if the Thread we want to kill, is the currentThread, we better not return
-// DO Not use new / delete in this Method, as it sometimes called from an Interrupt Handler with Interrupts disabled
+// If the Thread we want to kill is the currentThread, we better not return
+// DO NOT use new / delete in this Method, as it is sometimes called from an Interrupt Handler with Interrupts disabled
 void Thread::kill()
 {
   debug(THREAD, "kill: Called by <%s (%p)>. Preparing Thread <%s (%p)> for destruction\n", currentThread->getName(),
         currentThread, getName(), this);
-
-  switch_to_userspace_ = 0;
 
   state_ = ToBeDestroyed;
 


### PR DESCRIPTION
Setting `switch_to_userspace_ = 0` in Thread::kill() is not required and causes a race condition when Thread::kill() is called on another thread. Removing this unnecessary line of code fixes the race condition.


### Description of the race condition:
1. Thread B (in kernel mode, e.g. syscall/pagefault)
    * Gets interrupted, registers are saved in Thread B->kernel_registers_ [1]
    * Gets scheduled again, return from syscall/pagefault
      * Thread B->switch_to_userspace = 1

2. Thread A is scheduled and calls Thread B->kill()
    * Thread B->switch_to_userspace_ = 0

3. INTERRUPT 
    * Thread B is to be scheduled again
      * Scheduler sees Thread B->switch_to_userspace_ == 0
-> currentThreadRegisters = Thread B->kernel_registers_
-> arch_contextSwitch()

4. Thread B->kernel_registers_ still store the state that was saved when Thread B was last interrupted in kernel mode [1]
    * Thread B continues execution somewhere in kernel mode, causing havoc