### PR TITLE
Make SWEB debuggable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,11 @@ else(CMAKE_CROSSCOMPILING) # not cross compiling
   set(CMAKE_CROSS_COMPILE_FLAGS )
 endif(CMAKE_CROSSCOMPILING)
 
+if ("${DEBUG}" STREQUAL "1")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG=1")
+endif()
+
+
 # Searches for asm, c and cpp files and adds the library
 MACRO(ADD_PROJECT_LIBRARY LIBRARY_NAME)
 	arch2obj(arch_objs)

--- a/common/source/kernel/main.cpp
+++ b/common/source/kernel/main.cpp
@@ -42,6 +42,13 @@ extern "C" void removeBootTimeIdentMapping();
 
 extern "C" void startup()
 {
+#ifdef DEBUG
+  //software breakpoint for debugging
+  writeLine2Bochs("Wait for GDB!\n");
+  bool cont = false;
+  while(!cont);
+#endif
+
   writeLine2Bochs("Removing Boot Time Ident Mapping...\n");
   removeBootTimeIdentMapping();
   system_state = BOOTING;

--- a/utils/gdbinit
+++ b/utils/gdbinit
@@ -92,10 +92,16 @@ set $bt_pagefault_arg0 = 0
 # Don't stop on page faults
 #handle SIGSEGV nostop noprint nopass
 
+file /tmp/sweb/kernel64.x
+set architecture i386:x86-64
+
 # Connect to Bochs' gdbstub
-target remote localhost:1234
+target remote 127.0.0.1:1234
 
 # Welcome message
 echo \n\n
 echo You can now set trace and breakpoints.\n
 echo Enter 'continue' (or 'c') when you're done.\n
+
+set var cont=true
+break sweb_assert


### PR DESCRIPTION
This commit adds some helpers to ease with GDB-debugging sweb.
Compile and run with `./build debug`
Start gdb with `./start_gdb`

`rm -r /tmp/sweb/*` is necessary to switch between versions.