### PR TITLE
fix ksprintn declaration

### DIFF
--- a/common/include/ustl/ustringformat.h
+++ b/common/include/ustl/ustringformat.h
@@ -32,5 +32,5 @@ extern int
 kvprintf(char const *fmt, void (*func)(int, void*), void *arg, int radix, va_list ap);
 
 extern char *
-ksprintn(char* nbuf, register u_long ul, register int base, register int* lenp);
+ksprintn(char* nbuf, register u_long ul, register int base, register int* lenp, register int upper);
 


### PR DESCRIPTION
Tiny change, fixing the ksprintn declaration in the header to match the implementation in the cpp. 
To make the function call actually work :)