### PR TITLE
Prevent out-of-bounds read/write in RamFSInode

### DIFF
--- a/common/source/fs/ramfs/RamFSFile.cpp
+++ b/common/source/fs/ramfs/RamFSFile.cpp
@@ -26,7 +26,9 @@ RamFSFile::~RamFSFile()
 int32 RamFSFile::read(char *buffer, size_t count, l_off_t offset)
 {
   if ((flag_ == O_RDONLY) || (flag_ == O_RDWR))
-    return (f_inode_->readData(offset_ + offset, count, buffer));
+  {
+    return f_inode_->readData(offset_ + offset, count, buffer);
+  }
   else
   {
     // ERROR_FF
@@ -37,7 +39,9 @@ int32 RamFSFile::read(char *buffer, size_t count, l_off_t offset)
 int32 RamFSFile::write(const char *buffer, size_t count, l_off_t offset)
 {
   if ((flag_ == O_WRONLY) || (flag_ == O_RDWR))
-    return (f_inode_->writeData(offset_ + offset, count, buffer));
+  {
+    return f_inode_->writeData(offset_ + offset, count, buffer);
+  }
   else
   {
     // ERROR_FF

--- a/common/source/fs/ramfs/RamFSFile.cpp
+++ b/common/source/fs/ramfs/RamFSFile.cpp
@@ -25,7 +25,7 @@ RamFSFile::~RamFSFile()
 
 int32 RamFSFile::read(char *buffer, size_t count, l_off_t offset)
 {
-  if ((flag_ == O_RDONLY) || (flag_ == O_RDWR))
+  if (((flag_ == O_RDONLY) || (flag_ == O_RDWR)) && (mode_ & A_READABLE))
   {
     int32 read_bytes = f_inode_->readData(offset_ + offset, count, buffer);
     offset_ += read_bytes;
@@ -40,7 +40,7 @@ int32 RamFSFile::read(char *buffer, size_t count, l_off_t offset)
 
 int32 RamFSFile::write(const char *buffer, size_t count, l_off_t offset)
 {
-  if ((flag_ == O_WRONLY) || (flag_ == O_RDWR))
+  if (((flag_ == O_WRONLY) || (flag_ == O_RDWR)) && (mode_ & A_WRITABLE))
   {
     int32 written_bytes = f_inode_->writeData(offset_ + offset, count, buffer);
     offset_ += written_bytes;

--- a/common/source/fs/ramfs/RamFSFile.cpp
+++ b/common/source/fs/ramfs/RamFSFile.cpp
@@ -27,7 +27,9 @@ int32 RamFSFile::read(char *buffer, size_t count, l_off_t offset)
 {
   if ((flag_ == O_RDONLY) || (flag_ == O_RDWR))
   {
-    return f_inode_->readData(offset_ + offset, count, buffer);
+    int32 read_bytes = f_inode_->readData(offset_ + offset, count, buffer);
+    offset_ += read_bytes;
+    return read_bytes;
   }
   else
   {
@@ -40,7 +42,9 @@ int32 RamFSFile::write(const char *buffer, size_t count, l_off_t offset)
 {
   if ((flag_ == O_WRONLY) || (flag_ == O_RDWR))
   {
-    return f_inode_->writeData(offset_ + offset, count, buffer);
+    int32 written_bytes = f_inode_->writeData(offset_ + offset, count, buffer);
+    offset_ += written_bytes;
+    return written_bytes;
   }
   else
   {

--- a/common/source/fs/ramfs/RamFSInode.cpp
+++ b/common/source/fs/ramfs/RamFSInode.cpp
@@ -27,30 +27,36 @@ RamFSInode::~RamFSInode()
 
 int32 RamFSInode::readData(uint32 offset, uint32 size, char *buffer)
 {
-  if ((size + offset) > BASIC_ALLOC)
+  if(offset >= getSize())
   {
-    kprintfd("RamFSInode::ERROR: the size is bigger than size of the file\n");
-    assert(true);
+    return 0;
   }
 
+  uint32 read_size = Min(size, getSize() - offset);
+
   char *ptr_offset = data_ + offset;
-  memcpy(buffer, ptr_offset, size);
-  return size;
+  memcpy(buffer, ptr_offset, read_size);
+  return read_size;
 }
 
 int32 RamFSInode::writeData(uint32 offset, uint32 size, const char *buffer)
 {
-  if ((size + offset) > BASIC_ALLOC)
-  {
-    kprintfd("RamFSInode::ERROR: the size is bigger than size of the file\n");
-    assert(true);
-  }
-
   assert(i_type_ == I_FILE);
 
+  if(offset >= getSize())
+  {
+    return 0;
+  }
+
+  uint32 write_size = Min(size, getSize() - offset);
+  if(write_size != size)
+  {
+    debug(RAMFS, "WARNING: RamFS currently does not support expanding files via the write syscall\n");
+  }
+
   char *ptr_offset = data_ + offset;
-  memcpy(ptr_offset, buffer, size);
-  return size;
+  memcpy(ptr_offset, buffer, write_size);
+  return write_size;
 }
 
 int32 RamFSInode::mknod(Dentry *dentry)

--- a/common/source/fs/ramfs/RamFSInode.cpp
+++ b/common/source/fs/ramfs/RamFSInode.cpp
@@ -13,7 +13,7 @@ RamFSInode::RamFSInode(Superblock *super_block, uint32 inode_type) :
     Inode(super_block, inode_type), data_(0)
 {
   if (inode_type == I_FILE)
-    data_ = new char[BASIC_ALLOC];
+    data_ = new char[BASIC_ALLOC]();
 
   i_size_ = BASIC_ALLOC;
   i_nlink_ = 0;

--- a/common/source/kernel/Syscall.cpp
+++ b/common/source/kernel/Syscall.cpp
@@ -69,16 +69,20 @@ size_t Syscall::write(size_t fd, pointer buffer, size_t size)
   {
     return -1U;
   }
+
+  size_t num_written = 0;
+
   if (fd == fd_stdout) //stdout
   {
     debug(SYSCALL, "Syscall::write: %.*s\n", (int)size, (char*) buffer);
     kprintf("%.*s", (int)size, (char*) buffer);
+    num_written = size;
   }
   else
   {
-    VfsSyscall::write(fd, (char*) buffer, size);
+    num_written = VfsSyscall::write(fd, (char*) buffer, size);
   }
-  return size;
+  return num_written;
 }
 
 size_t Syscall::read(size_t fd, pointer buffer, size_t count)
@@ -87,7 +91,9 @@ size_t Syscall::read(size_t fd, pointer buffer, size_t count)
   {
     return -1U;
   }
+
   size_t num_read = 0;
+
   if (fd == fd_stdin)
   {
     //this doesn't! terminate a string with \0, gotta do that yourself


### PR DESCRIPTION
Fix for #119
(does not fix RamFS file size limitation)