### PR TITLE
Fix an error in gdbinit

### DIFF
--- a/utils/gdbinit
+++ b/utils/gdbinit
@@ -44,7 +44,7 @@ end
 # Called by hook-stop to check if we got a page fault
 define check_for_page_fault
 	# We are only interested in breaks that come from the PageFaultHandler
-	if($eip == arch_pageFaultHandler)
+	if($pc == arch_pageFaultHandler)
 		
 		# Check where the Pagefault occured
 		echo \n\n


### PR DESCRIPTION
I get the following error on each breakpoint in cgdb:

```
Error while running hook_stop:
Invalid type combination in equality test.
```

It seems that `$eip` is the instruction pointer on 32 bit platforms, while `$pc` works on all platforms gdb supports.

I found this solution on [Stack Overflow](https://stackoverflow.com/questions/9338744/invalid-register-eip). I'm not sure that's the right thing to do, it fixes the error for me though.