### PR TITLE
Add checks when setting thread state

### DIFF
--- a/arch/x86/common/source/ATADriver.cpp
+++ b/arch/x86/common/source/ATADriver.cpp
@@ -266,7 +266,7 @@ uint32 ATADriver::addRequest( BDRequest *br )
       ArchInterrupts::disableInterrupts();
       if (br->getStatus() == BDRequest::BD_QUEUED)
       {
-        currentThread->state_ = Sleeping;
+        currentThread->setState(Sleeping);
         ArchInterrupts::enableInterrupts();
         Scheduler::instance()->yield(); // this is necessary! setting state to sleep and continuing to run is a BAD idea
       }
@@ -300,7 +300,7 @@ bool ATADriver::waitForController( bool resetIfFailed = true )
 void ATADriver::nextRequest(BDRequest* br)
 {
   if(br->getThread())
-    br->getThread()->state_ = Running;
+    br->getThread()->setState(Running);
   request_list_ = br->getNextRequest();
 }
 

--- a/common/include/kernel/Thread.h
+++ b/common/include/kernel/Thread.h
@@ -101,7 +101,8 @@ class Thread
 
     Loader* loader_;
 
-    ThreadState state_;
+
+    void setState(ThreadState state);
 
     /**
      * A part of the single-chained waiters list for the locks.
@@ -127,11 +128,15 @@ class Thread
     Thread(Thread const &src);
     Thread &operator=(Thread const &src);
 
+    volatile ThreadState state_;
+
     size_t tid_;
 
     Terminal* my_terminal_;
 
   protected:
+    ThreadState getState() const;
+
     FileSystemInfo* working_dir_;
 
     ustl::string name_;

--- a/common/source/kernel/Scheduler.cpp
+++ b/common/source/kernel/Scheduler.cpp
@@ -111,6 +111,10 @@ void Scheduler::yield()
 
 void Scheduler::cleanupDeadThreads()
 {
+  /* Before adding new functionality to this function, consider if that
+     functionality could be implemented more cleanly in another place.
+     (e.g. Thread/Process destructor) */
+
   lockScheduling();
   uint32 thread_count_max = threads_.size();
   if (thread_count_max > 1024)

--- a/common/source/kernel/Thread.cpp
+++ b/common/source/kernel/Thread.cpp
@@ -64,7 +64,7 @@ void Thread::kill()
   debug(THREAD, "kill: Called by <%s (%p)>. Preparing Thread <%s (%p)> for destruction\n", currentThread->getName(),
         currentThread, getName(), this);
 
-  setState(ToBeDestroyed);
+  setState(ToBeDestroyed); // vvv Code below this line may not be executed vvv
 
   if (currentThread == this)
   {

--- a/common/source/kernel/UserProcess.cpp
+++ b/common/source/kernel/UserProcess.cpp
@@ -21,7 +21,6 @@ UserProcess::UserProcess(ustl::string filename, FileSystemInfo *fs_info, uint32 
   if (!loader_ || !loader_->loadExecutableAndInitProcess())
   {
     debug(USERPROCESS, "Error: loading %s failed!\n", filename.c_str());
-    loader_ = 0;
     kill();
     return;
   }


### PR DESCRIPTION
+ Some explanatory comments 
+ Disallow setting the state of other threads to Sleeping (not thread safe) 
+ Sanity check if someone tries to change thread state again after it was already set to ToBeDestroyed
+ Fix leak of Loader in UserProcess constructor when allocation was successful but loading the executable failed