### PR TITLE
Fixes arm_icp shift not realeased bug 

### DIFF
--- a/arch/arm/integratorcp/source/KeyboardManager.cpp
+++ b/arch/arm/integratorcp/source/KeyboardManager.cpp
@@ -51,7 +51,8 @@ void KeyboardManager::serviceIRQ(void)
   if(scancode == 0xf0)
     next_is_up_ = 1;
 #endif
-  if (scancode > 0x80)
+  // left shift release (0xAA) and right shift release (0xB6) must not be ignored when scancode set 1 is sent by qemu:
+  if (scancode > 0x80 && scancode != 0xAA && scancode != 0xB6)
     return;
 
 #if QEMU_SENDS_SCANCODE_SET2


### PR DESCRIPTION
If qemu sends scancode set 1 (like on my machine), the shift key is not released on arm_icp target, because of a too early return statement. (keyboard_status_ variable is not updated)

Fix tested on Ubuntu 14.04 x64 and Ubuntu 16.04 x64.