### PR TITLE
Fixed userspace printf implementation

### DIFF
--- a/userspace/libc/src/printf.c
+++ b/userspace/libc/src/printf.c
@@ -456,6 +456,10 @@ extern int printf(const char *format, ...)
           flag |= LONG;
           ++format;
           break;
+        case 'l':
+          flag |= LONG;
+          ++format;
+          break;
         default:
           break;
       }


### PR DESCRIPTION
It is now aware of the long format specifier.. (e.g. %lu did not work...)