### PR TITLE
made gets posix compatible and fixed caused bugs in shell

### DIFF
--- a/userspace/libc/src/scanf.c
+++ b/userspace/libc/src/scanf.c
@@ -433,17 +433,26 @@ int getchar()
  */
 char *gets(char *input_buffer, size_t buffer_size)
 {
-  char* cchar = input_buffer;
   unsigned int counter = 0;
   if (!buffer_size)
     return input_buffer;
 
-  do
-  {
-    cchar = input_buffer + counter;
-    read(STDIN_FILENO, (void*) cchar, 1);
+  int cchar = 0;
 
-    if (*cchar == '\b')
+  while((cchar = getchar()) != EOF)
+  {
+
+    if(cchar == '\r' || cchar == '\n' || (counter + 1) >= buffer_size) // there must be one space left for the \0 at end
+    {
+      *(input_buffer + counter) = '\0';
+      break;
+    }
+    else
+    {
+      *(input_buffer + counter) = (char)cchar;
+    }
+
+    if (cchar == '\b')
     {
       if (counter > 0)
         counter--;
@@ -452,10 +461,8 @@ char *gets(char *input_buffer, size_t buffer_size)
     {
       counter++;
     }
-  } while (*cchar != '\n' && *cchar != '\r' && counter < buffer_size);
 
-  if (buffer_size - counter)
-    input_buffer[counter] = '\0';
+  }
 
   return input_buffer;
 }

--- a/userspace/tests/shell.c
+++ b/userspace/tests/shell.c
@@ -25,7 +25,7 @@ void handle_command(char* buffer, int buffer_size)
   int lastIndex = 0;
   int pid;
 
-  for (c = 0; c < buffer_size && buffer[c]; c++)
+  for (c = 0; c < buffer_size; c++) //Do check for null termination at end of for loop to have one last run with \0
   {
     if (argsCount >= 10)
     {
@@ -33,7 +33,7 @@ void handle_command(char* buffer, int buffer_size)
       printf("Argument count is limited to 10 (no dynamic memory allocation) - all other arguments will be ignored\n");
       break;
     }
-    if (buffer[c] == '\r' || buffer[c] == '\n' || buffer[c] == ' ')
+    if (buffer[c] == '\r' || buffer[c] == '\n' || buffer[c] == ' ' || buffer[c] == '\0')
     {
       if (argsCount == -1)
       {
@@ -48,6 +48,11 @@ void handle_command(char* buffer, int buffer_size)
       argsCount++;
       lastIndex = c + 1;
 
+    }
+
+    if (buffer[c] == '\0')
+    {
+      break;
     }
   }
   if (strcmp(command, "ls") == 0)


### PR DESCRIPTION
According to the posix standard `gets` should have this behaviour:

> The gets() function shall read bytes from the standard input stream, stdin, into the array pointed to by s, until a \<newline\> is read or an end-of-file condition is encountered. Any \<newline\> shall be discarded and a null byte shall be placed immediately after the last byte read into the array.

The implementation before misses a check for EOF and a newline is also not replaced with a null byte.

Unfortunately this breaks the current implementation of the shell but I fixed them too.