### PR TITLE
Ignore printf specifiers in assert statements

### DIFF
--- a/userspace/libc/include/assert.h
+++ b/userspace/libc/include/assert.h
@@ -4,6 +4,6 @@
 #include <stdlib.h>
 
 #define assert(X) do { if (!(X)) {\
-    printf("Assertion failed: '" #X "', file %s, function %s, line %d\n", __FILE__, __FUNCTION__, __LINE__); \
+    printf("Assertion failed: '%s', file %s, function %s, line %d\n", #X, __FILE__, __FUNCTION__, __LINE__); \
  exit(-1); } } while (0)
 


### PR DESCRIPTION
The expression being asserted is currently being included as a string literal in the printf format specifier. This means that any printf format sequences in the expression (such as the modulo operator `%`) will be interpreted and may lead to unexpected behavior.

This PR changes the asserted expression to instead be passed as a string parameter, avoiding this issue.