### PR TITLE
Exterminate FakeThread with extreme prejudice

### DIFF
--- a/common/include/fs/FileSystemInfo.h
+++ b/common/include/fs/FileSystemInfo.h
@@ -105,3 +105,8 @@ class FileSystemInfo
     ustl::string pathname_;
 };
 
+extern FileSystemInfo* default_working_dir;
+// you use a different getcwd() method depending on where your cpp is being compiled
+//   (it can come either from Thread.cpp or from exe2minixfs.cpp)
+FileSystemInfo* getcwd();
+

--- a/common/source/fs/PathWalker.cpp
+++ b/common/source/fs/PathWalker.cpp
@@ -17,8 +17,6 @@
 #define CHAR_ROOT '/'
 #define SEPARATOR '/'
 
-extern FileSystemInfo* default_working_dir;
-
 int32 PathWalker::pathWalk(const char* pathname, uint32 flags_ __attribute__ ((unused)), Dentry*& dentry_,
                            VfsMount*& vfs_mount_)
 {
@@ -28,7 +26,7 @@ int32 PathWalker::pathWalk(const char* pathname, uint32 flags_ __attribute__ ((u
   // The last path component
   char* last_ = 0;
 
-  FileSystemInfo *fs_info = currentThread ? currentThread->getWorkingDirInfo() : default_working_dir;
+  FileSystemInfo *fs_info = getcwd();
   if (pathname == 0)
   {
     return PW_ENOTFOUND;
@@ -59,7 +57,7 @@ int32 PathWalker::pathWalk(const char* pathname, uint32 flags_ __attribute__ ((u
   debug(PATHWALKER, "PathWalk> return success - dentry: %p, vfs_mount: %p\n", dentry_, vfs_mount_);
 
   debug(PATHWALKER, "pathWalk> pathname : %s\n", pathname);
-  fs_info = currentThread ? currentThread->getWorkingDirInfo() : default_working_dir;
+  fs_info = getcwd();
   debug(PATHWALKER, "pathWalk> fs_info->pathname_.c_str() : %s\n", fs_info->pathname_.c_str());
   if (pathname == 0)
   {

--- a/common/source/fs/VfsSyscall.cpp
+++ b/common/source/fs/VfsSyscall.cpp
@@ -22,8 +22,6 @@
 #define SEPARATOR '/'
 #define CHAR_DOT '.'
 
-extern FileSystemInfo* default_working_dir;
-
 FileDescriptor* VfsSyscall::getFileDescriptor(uint32 fd)
 {
   extern Mutex global_fd_lock;
@@ -41,7 +39,7 @@ FileDescriptor* VfsSyscall::getFileDescriptor(uint32 fd)
 
 int32 VfsSyscall::dupChecking(const char* pathname, Dentry*& pw_dentry, VfsMount*& pw_vfs_mount)
 {
-  FileSystemInfo *fs_info = currentThread ? currentThread->getWorkingDirInfo() : default_working_dir;
+  FileSystemInfo *fs_info = getcwd();
   if (pathname == 0)
     return -1;
 
@@ -63,7 +61,7 @@ int32 VfsSyscall::dupChecking(const char* pathname, Dentry*& pw_dentry, VfsMount
 int32 VfsSyscall::mkdir(const char* pathname, int32)
 {
   debug(VFSSYSCALL, "(mkdir) \n");
-  FileSystemInfo *fs_info = currentThread ? currentThread->getWorkingDirInfo() : default_working_dir;
+  FileSystemInfo *fs_info = getcwd();
   Dentry* pw_dentry = 0;
   VfsMount* pw_vfs_mount = 0;
   if (dupChecking(pathname, pw_dentry, pw_vfs_mount) == 0)
@@ -111,7 +109,7 @@ int32 VfsSyscall::mkdir(const char* pathname, int32)
 
 Dirent* VfsSyscall::readdir(const char* pathname)
 {
-  FileSystemInfo *fs_info = currentThread ? currentThread->getWorkingDirInfo() : default_working_dir;
+  FileSystemInfo *fs_info = getcwd();
   Dentry* pw_dentry = 0;
   VfsMount* pw_vfs_mount = 0;
   if (dupChecking(pathname, pw_dentry, pw_vfs_mount) == 0)
@@ -162,7 +160,7 @@ Dirent* VfsSyscall::readdir(const char* pathname)
 
 int32 VfsSyscall::chdir(const char* pathname)
 {
-  FileSystemInfo *fs_info = currentThread ? currentThread->getWorkingDirInfo() : default_working_dir;
+  FileSystemInfo *fs_info = getcwd();
   Dentry* pw_dentry = 0;
   VfsMount* pw_vfs_mount = 0;
   if (dupChecking(pathname, pw_dentry, pw_vfs_mount) != 0)
@@ -273,7 +271,7 @@ int32 VfsSyscall::close(uint32 fd)
 
 int32 VfsSyscall::open(const char* pathname, uint32 flag)
 {
-  FileSystemInfo *fs_info = currentThread ? currentThread->getWorkingDirInfo() : default_working_dir;
+  FileSystemInfo *fs_info = getcwd();
   if (flag > (O_CREAT | O_RDWR))
   {
     debug(VFSSYSCALL, "(open) invalid parameter flag\n");

--- a/common/source/kernel/Thread.cpp
+++ b/common/source/kernel/Thread.cpp
@@ -108,6 +108,13 @@ FileSystemInfo* Thread::getWorkingDirInfo(void)
   return working_dir_;
 }
 
+FileSystemInfo* getcwd()
+{
+  if (FileSystemInfo* info = currentThread->getWorkingDirInfo())
+    return info;
+  return default_working_dir;
+}
+
 void Thread::setWorkingDirInfo(FileSystemInfo* working_dir)
 {
   working_dir_ = working_dir;

--- a/userspace/libc/src/printf.c
+++ b/userspace/libc/src/printf.c
@@ -495,7 +495,7 @@ extern int printf(const char *format, ...)
       if(*format == '.') {
         ++format; 
         char num[4];
-        c = 0;
+        size_t c = 0;
         for(; *format >= (c ? '0' : '1') && *format <= '9'; ++format, ++c)
             if( c < 4 )
                 num[c] = *format;

--- a/utils/exe2minixfs/exe2minixfs.cpp
+++ b/utils/exe2minixfs/exe2minixfs.cpp
@@ -16,7 +16,8 @@
 Superblock* superblock_;
 FileSystemInfo* default_working_dir;
 VfsMount vfs_dummy_;
-FakeThread* currentThread = 0;
+
+FileSystemInfo* getcwd() { return default_working_dir; }
 
 // obviously NOT atomic, we need this for compatability in single threaded host code
 size_t atomic_add(size_t& x,size_t y)

--- a/utils/exe2minixfs/types.h
+++ b/utils/exe2minixfs/types.h
@@ -32,10 +32,6 @@ typedef uint64_t l_off_t;
 
 class FileSystemInfo;
 
-class FakeThread { public: FileSystemInfo* getWorkingDirInfo() { return 0; } };
-
-extern FakeThread* currentThread;
-
 size_t atomic_add(size_t& x,size_t y);
 
 #endif


### PR DESCRIPTION
There's currently a contraption called `FakeThread` in `exe2minixfs` to enable natively compiling outside the context of SWEB.

It's also really ugly and unnecessary. So I'm replacing it with a `getcwd()` method.