### PR TITLE
Arm patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ utils/add-debug/*.d
 *.DS_Store
 *Thumbs.db
 .idea
+cmake-build-debug/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ if ("${ARCH}" STREQUAL "")
 endif("${ARCH}" STREQUAL "")
 MESSAGE("-- Target architecture: ${ARCH}")
 
+if ("${ARCH}" MATCHES "arm.*")
+  add_definitions(-DARM)
+endif("${ARCH}" MATCHES "arm.*")
+
 if ("${BIN_DIR_PREFIX}" STREQUAL "")
   SET (BIN_DIR_PREFIX "../")
 endif ("${BIN_DIR_PREFIX}" STREQUAL "")

--- a/arch/arm/common/include/ArchMemory.h
+++ b/arch/arm/common/include/ArchMemory.h
@@ -111,7 +111,10 @@ public:
 
 private:
 
-/** 
+  PageTableEntry* getPTE(size_t vpn);
+  static PageTableEntry* getIdentAddressOfPT(PageDirEntry *page_directory, uint32 pde_vpn);
+
+/**
  * Adds a page directory entry to the given page directory.
  * (In other words, adds the reference to a new page table to a given
  * page directory.)

--- a/arch/arm/common/source/ArchMemory.cpp
+++ b/arch/arm/common/source/ArchMemory.cpp
@@ -34,8 +34,6 @@ PageTableEntry* ArchMemory::getIdentAddressOfPT(PageDirEntry* page_directory, ui
 
 PageTableEntry* ArchMemory::getPTE(size_t vpn)
 {
-  assert(archmem_lock_.isHeldBy(currentThread));
-
   PageDirEntry *page_directory = (PageDirEntry *) getIdentAddressOfPPN(page_dir_page_);
   uint32 pde_vpn = vpn / PAGE_TABLE_ENTRIES;
   uint32 pte_vpn = vpn % PAGE_TABLE_ENTRIES;
@@ -186,7 +184,8 @@ ArchMemory::~ArchMemory()
         auto it = ustl::find(pt_ppns_.begin(), pt_ppns_.end(), page_directory[pde_vpn].pt.pt_ppn * 4 + i);
         if (it == pt_ppns_.end())
           free_pt_page = false;
-        pt_ppns_.erase(it);
+        else
+          pt_ppns_.erase(it);
       }
       if (free_pt_page)
         PageManager::instance()->freePPN(page_directory[pde_vpn].pt.pt_ppn - PHYS_OFFSET_4K);

--- a/arch/arm/common/source/ArchMemory.cpp
+++ b/arch/arm/common/source/ArchMemory.cpp
@@ -133,6 +133,7 @@ void ArchMemory::insertPT(uint32 pde_vpn)
   memset(((PageTableEntry *)getIdentAddressOfPPN(physical_page_table_page)) + offset * PAGE_TABLE_ENTRIES, 0, PT_SIZE);
   page_directory[pde_vpn].pt.pt_ppn = physical_page_table_page + PHYS_OFFSET_4K;
   page_directory[pde_vpn].pt.offset = offset;
+  page_directory[pde_vpn].pt.domain = 1;
   page_directory[pde_vpn].pt.size = PDE_SIZE_PT;
 }
 

--- a/arch/arm/common/source/InterruptUtils.cpp
+++ b/arch/arm/common/source/InterruptUtils.cpp
@@ -35,10 +35,11 @@ uint32 last_address;
 uint32 count;
 
 
-#define FLAG_FAULT_WRITING (1 << 10)
-#define FLAG_STATUS_MASK ((1 << 3) - 1)
+#define FLAG_FAULT_WRITING (0x800)
+#define FLAG_STATUS_MASK (0xf)
 #define FLAG_TRANSLATION_PAGE (7)
 #define FLAG_TRANSLATION_SECTION (5)
+
 //TODO extern "C" void arch_pageFaultHandler();
 void pageFaultHandler(uint32 address, uint32 type)
 {
@@ -65,6 +66,7 @@ void pageFaultHandler(uint32 address, uint32 type)
   if(data_fault)
   {
     fetch = 0;
+    // the writing bit is actually useless as it was introduced only in ARMv6
     writing = data_fault & FLAG_FAULT_WRITING;
     status = data_fault & FLAG_STATUS_MASK;
   }

--- a/arch/arm/common/source/boot.cpp
+++ b/arch/arm/common/source/boot.cpp
@@ -25,11 +25,12 @@ extern "C" void __attribute__((naked)) entry()
   initialiseBootTimePagingPTR();
   asm("mcr p15, 0, %[v], c2, c0, 0\n" : : [v]"r"(((uint8*)kernel_page_directory) + BOOT_OFFSET)); // set ttbr0
   asm("mcr p15, 0, %[v], c8, c7, 0\n" : : [v]"r"(0)); // tlb flush
-  asm("mcr p15, 0, %[v], c3, c0, 0\n" : : [v]"r"(3)); // set domain access control (full address space access for userspace)
+  asm("mcr p15, 0, %[v], c3, c0, 0\n" : : [v]"r"(0b111)); // set domain access control (domain 0 in manager mode, domain 1 in usr mode)
   asm("mrc p15, 0, r0, c1, c0, 0\n"
       "orr r0, r0, #0x1\n"          // set paging bit
       "bic r0, r0, #0x2\n"          // disable alignment fault bit
       "orr r0, r0, #0x400000\n"     // set unaligned memory access bit
+      "orr r0, r0, #0x800000\n"     // set disable subpages bit
       "mcr p15, 0, r0, c1, c0, 0\n" // enable paging
      );
   void (*PagingModePTR)() = &PagingMode; // create a blx jump instead of a bl jump

--- a/arch/arm/integratorcp/source/MMCDriver.cpp
+++ b/arch/arm/integratorcp/source/MMCDriver.cpp
@@ -171,15 +171,15 @@ int32 MMCDriver::writeBlock(uint32 address, void *buffer)
   uint32 response;
   mmc_send_cmd(24, address, &response);
   mmci->datalength = 512;
-  mmci->datactrl = PL181_DATA_ENABLE | PL181_DATA_DIRECTION | PL181_DATA_MODE;
+  mmci->datactrl = PL181_DATA_ENABLE | PL181_DATA_MODE;
   for (uint32 j = 0; j < 8; j++)
   {
+    while (!(mmci->status & PL181_STATUS_TXFIFOEMPTY));
     uint32 i;
     for (i = 0; i < 16; i++)
     {
-       mmci_fifo[i] = *((uint32*) buffer + j * 16 + i);
+      mmci_fifo[i] = *((uint32 *) buffer + j * 16 + i);
     }
-    while ((mmci->status & PL181_STATUS_TXFIFOEMPTY));
   }
   return 0;
 }


### PR DESCRIPTION
contains the following:
1. some beautification & util stuff
   - defines & utils for arms archmem
   - added clion project files to `.gitignore`
   - added ARM define for all arm targets
2. tinkered with arm paging
   - added new domain for usr pages (if i'm not mistaken the user can actually still access kernel pages atm...)
   - fixed: acces permissions have not been checked for user pages so far
   - fixed: subpages were enabled (doesn't go well with the current definition of the AP bits in a PTE)
   - fixed: the pf handler now correctly distinguishes between translation and permission pfs
   - the useless writeable bit would now be checked correctly if we had ARMv6
3. fixed arm/icp `MMCDevice::writBlock()`
4. fixed some bugs in arm archmem: the page table slot mechanism was really broken.
   - fixed madness in the dtor (dtor would exit early without freeing all pages)
   - fixed: `checkAndRemovePT` used to free ppns but keep them in the list of empty PT slots

sorry i cramped this into one pull request.