### PR TITLE
Remove unused entries from ArchThreadRegisters + cleanup x86_64 thread register creation

### DIFF
--- a/arch/x86/32/common/include/ArchThreads.h
+++ b/arch/x86/32/common/include/ArchThreads.h
@@ -27,11 +27,9 @@ struct ArchThreadRegisters
   uint32  fs;        // 52
   uint32  gs;        // 56
   uint32  ss;        // 60
-  uint32  dpl;       // 64
-  uint32  esp0;      // 68
-  uint32  ss0;       // 72
-  uint32  cr3;       // 76
-  uint32  fpu[27];   // 80
+  uint32  esp0;      // 64
+  uint32  cr3;       // 68
+  uint32  fpu[27];   // 72
 };
 
 class Thread;

--- a/arch/x86/32/common/include/ArchThreads.h
+++ b/arch/x86/32/common/include/ArchThreads.h
@@ -51,7 +51,6 @@ public:
 
 /**
  * allocates space for the currentThreadRegisters
- *
  */
   static void initialise();
 
@@ -61,18 +60,7 @@ public:
  * @param start_function instruction pointer is set so start function
  * @param stack stackpointer
  */
-  static void createKernelRegisters(ArchThreadRegisters *&info, void* start_function, void* stack);
-
-  /**
-   * changes an existing ArchThreadRegisters so that execution will start / continue
-   * at the function specified
-   * it does not change anything else, and if the thread info / thread was currently
-   * executing something else this will lead to a lot of problems
-   * USE WITH CARE, or better, don't use at all if you're a student
-   * @param the ArchThreadRegisters that we are going to mangle
-   * @param start_function instruction pointer for the next instruction that gets executed
-   */
-  static void changeInstructionPointer(ArchThreadRegisters *info, void* function);
+  static void createKernelRegisters(ArchThreadRegisters *&info, void* start_function, void* kernel_stack);
 
 /**
  * creates the ArchThreadRegisters for a user thread
@@ -82,6 +70,17 @@ public:
  * @param kernel_stack pointer to the kernel stack
  */
   static void createUserRegisters(ArchThreadRegisters *&info, void* start_function, void* user_stack, void* kernel_stack);
+
+/**
+ * changes an existing ArchThreadRegisters so that execution will start / continue
+ * at the function specified
+ * it does not change anything else, and if the thread info / thread was currently
+ * executing something else this will lead to a lot of problems
+ * USE WITH CARE, or better, don't use at all if you're a student
+ * @param the ArchThreadRegisters that we are going to mangle
+ * @param start_function instruction pointer for the next instruction that gets executed
+ */
+  static void changeInstructionPointer(ArchThreadRegisters *info, void* function);
 
 /**
  *
@@ -149,12 +148,11 @@ public:
 private:
 
 /**
- * creates the ArchThreadRegisters for a thread
+ * creates the ArchThreadRegisters for a thread (common setup for kernel and user registers)
  * @param info where the ArchThreadRegisters is saved
- * @param start_function instruction pointer is set so start function
+ * @param start_function instruction pointer is set to start function
  * @param stack stackpointer
  */
   static void createBaseThreadRegisters(ArchThreadRegisters *&info, void* start_function, void* stack);
-
 };
 

--- a/arch/x86/32/common/source/ArchThreads.cpp
+++ b/arch/x86/32/common/source/ArchThreads.cpp
@@ -51,7 +51,6 @@ void ArchThreads::createKernelRegisters(ArchThreadRegisters *&info, void* start_
   info->ds      = KERNEL_DS;
   info->es      = KERNEL_DS;
   info->ss      = KERNEL_SS;
-  info->dpl     = DPL_KERNEL;
 }
 
 void ArchThreads::createUserRegisters(ArchThreadRegisters *&info, void* start_function, void* user_stack, void* kernel_stack)
@@ -62,8 +61,6 @@ void ArchThreads::createUserRegisters(ArchThreadRegisters *&info, void* start_fu
   info->ds      = USER_DS;
   info->es      = USER_DS;
   info->ss      = USER_SS;
-  info->dpl     = DPL_USER;
-  info->ss0     = KERNEL_SS;
   info->esp0    = (size_t)kernel_stack;
 }
 

--- a/arch/x86/64/include/ArchThreads.h
+++ b/arch/x86/64/include/ArchThreads.h
@@ -60,7 +60,6 @@ public:
 
 /**
  * allocates space for the currentThreadRegisters
- *
  */
   static void initialise();
 
@@ -70,18 +69,7 @@ public:
  * @param start_function instruction pointer is set so start function
  * @param stack stackpointer
  */
-  static void createKernelRegisters(ArchThreadRegisters *&info, void* start_function, void* stack);
- 
-  /**
-   * changes an existing ArchThreadRegisters so that execution will start / continue
-   * at the function specified
-   * it does not change anything else, and if the thread info / thread was currently
-   * executing something else this will lead to a lot of problems
-   * USE WITH CARE, or better, don't use at all if you're a student
-   * @param the ArchThreadRegisters that we are going to mangle
-   * @param start_function instruction pointer for the next instruction that gets executed
-   */
-  static void changeInstructionPointer(ArchThreadRegisters *info, void* function);
+  static void createKernelRegisters(ArchThreadRegisters *&info, void* start_function, void* kernel_stack);
 
 /**
  * creates the ArchThreadRegisters for a user thread
@@ -91,6 +79,17 @@ public:
  * @param kernel_stack pointer to the kernel stack
  */
   static void createUserRegisters(ArchThreadRegisters *&info, void* start_function, void* user_stack, void* kernel_stack);
+
+/**
+ * changes an existing ArchThreadRegisters so that execution will start / continue
+ * at the function specified
+ * it does not change anything else, and if the thread info / thread was currently
+ * executing something else this will lead to a lot of problems
+ * USE WITH CARE, or better, don't use at all if you're a student
+ * @param the ArchThreadRegisters that we are going to mangle
+ * @param start_function instruction pointer for the next instruction that gets executed
+ */
+  static void changeInstructionPointer(ArchThreadRegisters *info, void* function);
 
 /**
  *
@@ -152,5 +151,14 @@ public:
    * @param thread
    */
   static void debugCheckNewThread(Thread* thread);
+
+private:
+  /**
+   * creates the ArchThreadRegisters for a thread (common setup for kernel and user registers)
+   * @param info where the ArchThreadRegisters is saved
+   * @param start_function instruction pointer is set to start function
+   * @param stack stackpointer
+   */
+  static void createBaseThreadRegisters(ArchThreadRegisters *&info, void* start_function, void* stack);
 };
 

--- a/arch/x86/64/include/ArchThreads.h
+++ b/arch/x86/64/include/ArchThreads.h
@@ -35,11 +35,9 @@ struct ArchThreadRegisters
   uint64  fs;        // 168
   uint64  gs;        // 176
   uint64  ss;        // 184
-  uint64  dpl;       // 192
-  uint64  rsp0;      // 200
-  uint64  ss0;       // 208
-  uint64  cr3;       // 216
-  uint32  fpu[28];   // 224
+  uint64  rsp0;      // 192
+  uint64  cr3;       // 200
+  uint32  fpu[28];   // 208
 };
 
 class Thread;

--- a/arch/x86/64/source/ArchThreads.cpp
+++ b/arch/x86/64/source/ArchThreads.cpp
@@ -41,7 +41,6 @@ void ArchThreads::createKernelRegisters(ArchThreadRegisters *&info, void* start_
   info->es      = KERNEL_DS;
   info->ss      = KERNEL_SS;
   info->rflags  = 0x200;
-  info->dpl     = DPL_KERNEL;
   info->rsp     = (size_t)stack;
   info->rbp     = (size_t)stack;
   info->rip     = (size_t)start_function;
@@ -73,9 +72,7 @@ void ArchThreads::createUserRegisters(ArchThreadRegisters *&info, void* start_fu
   info->ds      = USER_DS;
   info->es      = USER_DS;
   info->ss      = USER_SS;
-  info->ss0     = KERNEL_SS;
   info->rflags  = 0x200;
-  info->dpl     = DPL_USER;
   info->rsp     = (size_t)user_stack;
   info->rbp     = (size_t)user_stack;
   info->rsp0    = (size_t)kernel_stack;

--- a/arch/x86/64/source/ArchThreads.cpp
+++ b/arch/x86/64/source/ArchThreads.cpp
@@ -11,7 +11,7 @@ extern PageMapLevel4Entry kernel_page_map_level_4[];
 
 void ArchThreads::initialise()
 {
-  currentThreadRegisters = (ArchThreadRegisters*) new uint8[sizeof(ArchThreadRegisters)];
+  currentThreadRegisters = new ArchThreadRegisters{};
 
   /** Enable SSE for floating point instructions in long mode **/
   asm volatile ("movq %%cr0, %%rax\n"
@@ -30,66 +30,53 @@ void ArchThreads::setAddressSpace(Thread *thread, ArchMemory& arch_memory)
     thread->user_registers_->cr3 = arch_memory.page_map_level_4_ * PAGE_SIZE;
 }
 
-void ArchThreads::createKernelRegisters(ArchThreadRegisters *&info, void* start_function, void* stack)
+void ArchThreads::createBaseThreadRegisters(ArchThreadRegisters *&info, void* start_function, void* stack)
 {
-  info = (ArchThreadRegisters*)new uint8[sizeof(ArchThreadRegisters)];
-  memset((void*)info, 0, sizeof(ArchThreadRegisters));
-  pointer pml4 = (pointer)VIRTUAL_TO_PHYSICAL_BOOT(kernel_page_map_level_4);
+  info = new ArchThreadRegisters{};
+  pointer pml4 = (pointer)VIRTUAL_TO_PHYSICAL_BOOT(((pointer)ArchMemory::getRootOfKernelPagingStructure()));
+
+  info->rflags  = 0x200;
+  info->cr3     = pml4;
+  info->rsp     = (size_t)stack;
+  info->rbp     = (size_t)stack;
+  info->rip     = (size_t)start_function;
+
+  /* fpu (=fninit) */
+  info->fpu[0] = 0xFFFF037F;
+  info->fpu[1] = 0xFFFF0000;
+  info->fpu[2] = 0xFFFFFFFF;
+  info->fpu[3] = 0x00000000;
+  info->fpu[4] = 0x00000000;
+  info->fpu[5] = 0x00000000;
+  info->fpu[6] = 0xFFFF0000;
+}
+
+void ArchThreads::createKernelRegisters(ArchThreadRegisters *&info, void* start_function, void* kernel_stack)
+{
+  createBaseThreadRegisters(info, start_function, kernel_stack);
 
   info->cs      = KERNEL_CS;
   info->ds      = KERNEL_DS;
   info->es      = KERNEL_DS;
   info->ss      = KERNEL_SS;
-  info->rflags  = 0x200;
-  info->rsp     = (size_t)stack;
-  info->rbp     = (size_t)stack;
-  info->rip     = (size_t)start_function;
-  info->cr3     = pml4;
   assert(info->cr3);
-
- /* fpu (=fninit) */
-  info->fpu[0] = 0xFFFF037F;
-  info->fpu[1] = 0xFFFF0000;
-  info->fpu[2] = 0xFFFFFFFF;
-  info->fpu[3] = 0x00000000;
-  info->fpu[4] = 0x00000000;
-  info->fpu[5] = 0x00000000;
-  info->fpu[6] = 0xFFFF0000;
-}
-
-void ArchThreads::changeInstructionPointer(ArchThreadRegisters *info, void* function)
-{
-  info->rip = (size_t)function;
 }
 
 void ArchThreads::createUserRegisters(ArchThreadRegisters *&info, void* start_function, void* user_stack, void* kernel_stack)
 {
-  info = (ArchThreadRegisters*)new uint8[sizeof(ArchThreadRegisters)];
-  memset((void*)info, 0, sizeof(ArchThreadRegisters));
-  pointer pml4 = (pointer)VIRTUAL_TO_PHYSICAL_BOOT(kernel_page_map_level_4);
+  createBaseThreadRegisters(info, start_function, user_stack);
 
   info->cs      = USER_CS;
   info->ds      = USER_DS;
   info->es      = USER_DS;
   info->ss      = USER_SS;
-  info->rflags  = 0x200;
-  info->rsp     = (size_t)user_stack;
-  info->rbp     = (size_t)user_stack;
   info->rsp0    = (size_t)kernel_stack;
-  info->rip     = (size_t)start_function;
-  info->cr3     = pml4;
   assert(info->cr3);
+}
 
- /* fpu (=fninit) */
-  info->fpu[0] = 0xFFFF037F;
-  info->fpu[1] = 0xFFFF0000;
-  info->fpu[2] = 0xFFFFFFFF;
-  info->fpu[3] = 0x00000000;
-  info->fpu[4] = 0x00000000;
-  info->fpu[5] = 0x00000000;
-  info->fpu[6] = 0xFFFF0000;
-  //kprintfd("ArchThreads::create: values done\n");
-
+void ArchThreads::changeInstructionPointer(ArchThreadRegisters *info, void* function)
+{
+  info->rip = (size_t)function;
 }
 
 void ArchThreads::yield()


### PR DESCRIPTION
* Remove dpl and ss0 from ArchThreadRegisters on x86
* Cleanup x86 64bit thread register creation to be the same as on 32bit