### PR TITLE
Fix cmake add-debug build

### DIFF
--- a/utils/add-debug/dwarf/CMakeLists.txt
+++ b/utils/add-debug/dwarf/CMakeLists.txt
@@ -5,16 +5,16 @@ cmake_minimum_required(VERSION 3.0.2)
 
 set(CMAKE_CXX_STANDARD 11)
 
+add_custom_command(
+    OUTPUT to_string.cc
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../elf/enum-print.py" "${CMAKE_CURRENT_BINARY_DIR}/../elf/enum-print.py"
+    COMMAND make to_string.cc
+    DEPENDS ../elf/enum-print.py dwarf++.hh data.hh Makefile internal.hh
+)
 
 add_library(dwarf++ STATIC
     dwarf.cc cursor.cc die.cc value.cc abbrev.cc
     expr.cc rangelist.cc line.cc attrs.cc
     die_str_map.cc elf.cc to_string.cc
-)
-
-add_custom_command(
-    TARGET dwarf++
-    PRE_BUILD
-    COMMAND make to_string.cc
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )

--- a/utils/add-debug/elf/CMakeLists.txt
+++ b/utils/add-debug/elf/CMakeLists.txt
@@ -5,12 +5,11 @@ cmake_minimum_required(VERSION 3.0.2)
 
 set(CMAKE_CXX_STANDARD 11)
 
+add_custom_command(
+    OUTPUT to_string.cc
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
+    COMMAND make to_string.cc
+    DEPENDS enum-print.py data.hh to_hex.hh Makefile
+)
 
 add_library(elf++ STATIC elf.cc mmap_loader.cc to_string.cc)
-
-add_custom_command(
-    TARGET elf++
-    PRE_BUILD
-    COMMAND make to_string.cc
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-)


### PR DESCRIPTION
Generate required `to_string.cc` file in cmake build. Fixes https://github.com/IAIK/sweb/commit/f50c40e0a87b02b31b0cbb7b926a3d440650180e#r27386483

Additionally, `to_string.cc` is now generated out-of-tree instead of in the source folder.

Copying `enum-print.py` to `BIN_DIR/../elf/` is fairly ugly, but that's how it's required by the library Makefile...