### PR TITLE
Remove unused code for mapping large pages

### DIFF
--- a/arch/arm/common/include/ArchMemory.h
+++ b/arch/arm/common/include/ArchMemory.h
@@ -29,10 +29,8 @@ public:
  * @param physical_page
  * @param user_access PTE User/Supervisor Flag, governing the binary Paging
  * Privilege Mechanism
- * @param page_size Optional, defaults to 4k pages, but you ned to set it to
- * 1024*4096 if you want to map a 4m page
  */
-  void mapPage(uint32 virtual_page, uint32 physical_page, uint32 user_access, uint32 page_size=PAGE_SIZE);
+  bool mapPage(uint32 virtual_page, uint32 physical_page, uint32 user_access);
 
 /**
  * removes the mapping to a virtual_page by marking its PTE Entry as non valid

--- a/arch/arm/common/source/ArchMemory.cpp
+++ b/arch/arm/common/source/ArchMemory.cpp
@@ -46,7 +46,7 @@ PageTableEntry* ArchMemory::getPTE(size_t vpn)
 
 ArchMemory::ArchMemory()
 {
-  page_dir_page_ = PageManager::instance()->allocPPN(4 * PAGE_SIZE);
+  page_dir_page_ = PageManager::instance()->allocPPN(PD_SIZE);
   debug(A_MEMORY, "ArchMemory::ArchMemory(): Got new Page no. %x\n", page_dir_page_);
 
   PageDirEntry *new_page_directory = (PageDirEntry*) getIdentAddressOfPPN(page_dir_page_);
@@ -195,7 +195,7 @@ ArchMemory::~ArchMemory()
         PageManager::instance()->freePPN(page_directory[pde_vpn].pt.pt_ppn - PHYS_OFFSET_4K);
     }
   }
-  PageManager::instance()->freePPN(page_dir_page_);
+  PageManager::instance()->freePPN(page_dir_page_, PD_SIZE);
 }
 
 pointer ArchMemory::checkAddressValid(uint32 vaddress_to_check)

--- a/arch/x86/32/include/ArchMemory.h
+++ b/arch/x86/32/include/ArchMemory.h
@@ -24,10 +24,8 @@ public:
  * @param physical_page
  * @param user_access PTE User/Supervisor Flag, governing the binary Paging
  * Privilege Mechanism
- * @param page_size Optional, defaults to 4k pages, but you ned to set it to
- * 1024*4096 if you want to map a 4m page
  */
-  void mapPage(uint32 virtual_page, uint32 physical_page, uint32 user_access, uint32 page_size=PAGE_SIZE);
+  bool mapPage(uint32 virtual_page, uint32 physical_page, uint32 user_access);
 
 /**
  * removes the mapping to a virtual_page by marking its PTE Entry as non valid

--- a/arch/x86/32/pae/include/ArchMemory.h
+++ b/arch/x86/32/pae/include/ArchMemory.h
@@ -27,10 +27,8 @@ public:
  * @param physical_page
  * @param user_access PTE User/Supervisor Flag, governing the binary Paging
  * Privilege Mechanism
- * @param page_size Optional, defaults to 4k pages, but you ned to set it to
- * 1024*4096 if you want to map a 4m page
  */
-  void mapPage(uint32 virtual_page, uint32 physical_page, uint32 user_access, uint32 page_size=PAGE_SIZE);
+  bool mapPage(uint32 virtual_page, uint32 physical_page, uint32 user_access);
 
 /**
  * removes the mapping to a virtual_page by marking its PTE Entry as non valid

--- a/arch/x86/32/source/ArchMemory.cpp
+++ b/arch/x86/32/source/ArchMemory.cpp
@@ -86,21 +86,29 @@ void ArchMemory::insertPT(uint32 pde_vpn, uint32 physical_page_table_page)
   page_directory[pde_vpn].pt.present = 1;
 }
 
-void ArchMemory::mapPage(uint32 virtual_page, uint32 physical_page, uint32 user_access, uint32 page_size)
+bool ArchMemory::mapPage(uint32 virtual_page, uint32 physical_page, uint32 user_access)
 {
   RESOLVEMAPPING(page_dir_page_, virtual_page);
 
-  assert(page_size == PAGE_SIZE);
-
-  if (page_directory[pde_vpn].pt.present == 0)
+  if(page_directory[pde_vpn].pt.present == 0)
+  {
     insertPT(pde_vpn, PageManager::instance()->allocPPN());
+  }
+  assert(!page_directory[pde_vpn].page.size);
+
 
   PageTableEntry *pte_base = (PageTableEntry *) getIdentAddressOfPPN(page_directory[pde_vpn].pt.page_table_ppn);
-  assert(!pte_base[pte_vpn].present);
-  pte_base[pte_vpn].writeable = 1;
-  pte_base[pte_vpn].user_access = user_access;
-  pte_base[pte_vpn].page_ppn = physical_page;
-  pte_base[pte_vpn].present = 1;
+  if(pte_base[pte_vpn].present == 0)
+  {
+    pte_base[pte_vpn].writeable = 1;
+    pte_base[pte_vpn].user_access = user_access;
+    pte_base[pte_vpn].page_ppn = physical_page;
+    pte_base[pte_vpn].present = 1;
+    return true;
+  }
+
+  assert(false);
+  return false;
 }
 
 pointer ArchMemory::checkAddressValid(uint32 vaddress_to_check)

--- a/arch/x86/64/include/ArchMemory.h
+++ b/arch/x86/64/include/ArchMemory.h
@@ -41,10 +41,8 @@ public:
  * @param physical_page
  * @param user_access PTE User/Supervisor Flag, governing the binary Paging
  * Privilege Mechanism
- * @param page_size Optional, defaults to 4k pages, but you ned to set it to
- * 512*4096 if you want to map a 2m page
  */
-  bool mapPage(uint64 virtual_page, uint64 physical_page, uint64 user_access, uint64 page_size=PAGE_SIZE);
+  bool mapPage(uint64 virtual_page, uint64 physical_page, uint64 user_access);
 
 /**
  * removes the mapping to a virtual_page by marking its PTE Entry as non valid

--- a/arch/x86/64/source/boot.32.C
+++ b/arch/x86/64/source/boot.32.C
@@ -76,8 +76,6 @@ static void memset(char* block, char c, size_t length)
     block[i] = c;
 }
 
-extern uint8 boot_stack[];
-
 static void setSegmentDescriptor(uint32 index, uint32 baseH, uint32 baseL, uint32 limit, uint8 dpl, uint8 code,
                                  uint8 tss)
 {

--- a/common/source/kernel/Loader.cpp
+++ b/common/source/kernel/Loader.cpp
@@ -58,7 +58,7 @@ void Loader::loadPage(pointer virtual_address)
         {
           program_binary_lock_.release();
           PageManager::instance()->freePPN(ppn);
-          debug(LOADER, "ERROR! Some parts of the content could not be load from the binary.\n");
+          debug(LOADER, "ERROR! Some parts of the content could not be loaded from the binary.\n");
           Syscall::exit(999);
         }
         found_page_content = true;
@@ -78,7 +78,7 @@ void Loader::loadPage(pointer virtual_address)
     Syscall::exit(666);
   }
 
-  arch_memory_.mapPage(virt_page_start_addr / PAGE_SIZE, ppn, true, PAGE_SIZE);
+  arch_memory_.mapPage(virt_page_start_addr / PAGE_SIZE, ppn, true);
   debug(LOADER, "Loader:loadPage: Load request for address %p has been successfully finished.\n", (void*)virtual_address);
 }
 


### PR DESCRIPTION
mapPage() support for mapping large pages is unused + unmapPage() doesn't support unmapping large pages in any case

Also fixes a page leak on ARM when a process is destroyed