### PR TITLE
Remove large page support from x86_32_pae unmapPage()

### DIFF
--- a/arch/arm/common/source/ArchMemory.cpp
+++ b/arch/arm/common/source/ArchMemory.cpp
@@ -96,18 +96,16 @@ void ArchMemory::unmapPage(uint32 virtual_page)
   uint32 pte_vpn = virtual_page % PAGE_TABLE_ENTRIES;
 
   assert(page_directory[pde_vpn].pt.size != PDE_SIZE_PAGE && "Trying to unmap a small page but here is a large page");
+  assert(page_directory[pde_vpn].pt.size == PDE_SIZE_PT);
 
-  if (page_directory[pde_vpn].pt.size == PDE_SIZE_PT)
-  {
-    PageTableEntry *pte_base = getIdentAddressOfPT(page_directory, pde_vpn);
-    if (pte_base[pte_vpn].size == PTE_SIZE_SMALL)
-    {
-      pte_base[pte_vpn].size = PTE_SIZE_NONE;
-      PageManager::instance()->freePPN(pte_base[pte_vpn].page_ppn - PHYS_OFFSET_4K);
-      ((uint32*)pte_base)[pte_vpn] = 0; // for easier debugging
-    }
-    checkAndRemovePT(pde_vpn);
-  }
+  PageTableEntry *pte_base = getIdentAddressOfPT(page_directory, pde_vpn);
+  assert(pte_base[pte_vpn].size == PTE_SIZE_SMALL);
+
+  pte_base[pte_vpn].size = PTE_SIZE_NONE;
+  PageManager::instance()->freePPN(pte_base[pte_vpn].page_ppn - PHYS_OFFSET_4K);
+  ((uint32*)pte_base)[pte_vpn] = 0; // for easier debugging
+
+  checkAndRemovePT(pde_vpn);
 }
 
 void ArchMemory::insertPT(uint32 pde_vpn)

--- a/arch/x86/32/source/ArchMemory.cpp
+++ b/arch/x86/32/source/ArchMemory.cpp
@@ -68,9 +68,11 @@ void ArchMemory::unmapPage(uint32 virtual_page)
 
   PageTableEntry *pte_base = (PageTableEntry *) getIdentAddressOfPPN(page_directory[pde_vpn].pt.page_table_ppn);
   assert(pte_base[pte_vpn].present);
+
   pte_base[pte_vpn].present = 0;
   PageManager::instance()->freePPN(pte_base[pte_vpn].page_ppn);
   ((uint32*)pte_base)[pte_vpn] = 0; // for easier debugging
+
   checkAndRemovePT(pde_vpn);
 }
 


### PR DESCRIPTION
Apparently I missed that in the last commit.

Also changed unmapPage() for ARM and x86_32_pae to assert when page is not mapped (matches behavior of x86_64 and x86_32).