### PR TITLE
Fixed crash when selecting boot option with resolution

### DIFF
--- a/arch/x86/64/source/ArchMemory.cpp
+++ b/arch/x86/64/source/ArchMemory.cpp
@@ -231,8 +231,7 @@ const ArchMemoryMapping ArchMemory::resolveMapping(uint64 pml4, uint64 vpage)
       else if (m.pd[m.pdi].page.present)
       {
         m.page_size = PAGE_SIZE * PAGE_TABLE_ENTRIES;
-        m.page_ppn = m.pd[m.pdi].page.page_ppn;
-        assert(m.page_ppn < PageManager::instance()->getTotalNumPages());
+        m.page_ppn = m.pd[m.pdi].page.page_ppn;;
         m.page = getIdentAddressOfPPN(m.pd[m.pdi].page.page_ppn);
       }
     }

--- a/arch/x86/64/source/ArchMemory.cpp
+++ b/arch/x86/64/source/ArchMemory.cpp
@@ -231,7 +231,7 @@ const ArchMemoryMapping ArchMemory::resolveMapping(uint64 pml4, uint64 vpage)
       else if (m.pd[m.pdi].page.present)
       {
         m.page_size = PAGE_SIZE * PAGE_TABLE_ENTRIES;
-        m.page_ppn = m.pd[m.pdi].page.page_ppn;;
+        m.page_ppn = m.pd[m.pdi].page.page_ppn;
         m.page = getIdentAddressOfPPN(m.pd[m.pdi].page.page_ppn);
       }
     }


### PR DESCRIPTION
Selecting an option with resolution at startup, the assert in ArchMemory.cpp:235 would fail an cause a kernel panic.