### PR TITLE
Include kprintf in debug.h

### DIFF
--- a/common/include/console/debug.h
+++ b/common/include/console/debug.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "kprintf.h"
+
 enum AnsiColor
 {
   Ansi_Red = 31,


### PR DESCRIPTION
To ensure kprintf() is automatically visible when using debug(). 
Currently using debug() requires including both debug.h and kprintf.h
(In most cases it's included somewhere in other include files, but not when e.g. working in a completely new file that only includes debug.h and no other header files)