### PR TITLE
Debug check outstanding EOI signals for x86

### DIFF
--- a/arch/x86/32/common/source/ArchInterrupts.cpp
+++ b/arch/x86/32/common/source/ArchInterrupts.cpp
@@ -180,6 +180,11 @@ extern TSS *g_tss;
 extern "C" void arch_contextSwitch()
 {
   assert(currentThread->isStackCanaryOK() && "Kernel stack corruption detected.");
+  if(outstanding_EOIs)
+  {
+          debug(A_INTERRUPTS, "%zu outstanding End-Of-Interrupt signal(s) on context switch. Probably called yield in the wrong place (e.g. in the scheduler/IRQ0)\n", outstanding_EOIs);
+          assert(!outstanding_EOIs);
+  }
   ArchThreadRegisters info = *currentThreadRegisters; // optimization: local copy produces more efficient code in this case
   if (currentThread->switch_to_userspace_)
   {

--- a/arch/x86/32/common/source/ArchThreads.cpp
+++ b/arch/x86/32/common/source/ArchThreads.cpp
@@ -70,7 +70,7 @@ void ArchThreads::changeInstructionPointer(ArchThreadRegisters *info, void* func
 
 void ArchThreads::yield()
 {
-  asm("int $65");
+  __asm__ __volatile__("int $65");
 }
 
 uint32 ArchThreads::testSetLock(uint32 &lock, uint32 new_value)

--- a/arch/x86/32/common/source/InterruptUtils.cpp
+++ b/arch/x86/32/common/source/InterruptUtils.cpp
@@ -21,6 +21,8 @@
 #include "PageFaultHandler.h"
 #include "Stabs2DebugInfo.h"
 
+#include "8259.h"
+
 #define LO_WORD(x) (((uint32)(x)) & 0x0000FFFF)
 #define HI_WORD(x) ((((uint32)(x)) >> 16) & 0x0000FFFF)
 
@@ -116,6 +118,7 @@ extern "C" void arch_irqHandler_0();
 extern "C" void arch_contextSwitch();
 extern "C" void irqHandler_0()
 {
+  ++outstanding_EOIs;
   ArchCommon::drawHeartBeat();
 
   Scheduler::instance()->incTicks();
@@ -150,6 +153,7 @@ extern "C" void pageFaultHandler(uint32 address, uint32 error)
 extern "C" void arch_irqHandler_1();
 extern "C" void irqHandler_1()
 {
+  ++outstanding_EOIs;
   KeyboardManager::instance()->serviceIRQ();
   ArchInterrupts::EndOfInterrupt(1);
 }
@@ -158,6 +162,7 @@ extern "C" void arch_irqHandler_3();
 extern "C" void irqHandler_3()
 {
   kprintfd("IRQ 3 called\n");
+  ++outstanding_EOIs;
   SerialManager::getInstance()->service_irq(3);
   ArchInterrupts::EndOfInterrupt(3);
   kprintfd("IRQ 3 ended\n");
@@ -167,6 +172,7 @@ extern "C" void arch_irqHandler_4();
 extern "C" void irqHandler_4()
 {
   kprintfd("IRQ 4 called\n");
+  ++outstanding_EOIs;
   SerialManager::getInstance()->service_irq(4);
   ArchInterrupts::EndOfInterrupt(4);
   kprintfd("IRQ 4 ended\n");
@@ -183,6 +189,7 @@ extern "C" void arch_irqHandler_9();
 extern "C" void irqHandler_9()
 {
   kprintfd("IRQ 9 called\n");
+  ++outstanding_EOIs;
   BDManager::getInstance()->serviceIRQ(9);
   ArchInterrupts::EndOfInterrupt(9);
 }
@@ -191,6 +198,7 @@ extern "C" void arch_irqHandler_11();
 extern "C" void irqHandler_11()
 {
   kprintfd("IRQ 11 called\n");
+  ++outstanding_EOIs;
   BDManager::getInstance()->serviceIRQ(11);
   ArchInterrupts::EndOfInterrupt(11);
 }
@@ -199,6 +207,7 @@ extern "C" void arch_irqHandler_14();
 extern "C" void irqHandler_14()
 {
   //kprintfd( "IRQ 14 called\n" );
+  ++outstanding_EOIs;
   BDManager::getInstance()->serviceIRQ(14);
   ArchInterrupts::EndOfInterrupt(14);
 }
@@ -207,6 +216,7 @@ extern "C" void arch_irqHandler_15();
 extern "C" void irqHandler_15()
 {
   //kprintfd( "IRQ 15 called\n" );
+  ++outstanding_EOIs;
   BDManager::getInstance()->serviceIRQ(15);
   ArchInterrupts::EndOfInterrupt(15);
 }

--- a/arch/x86/64/source/ArchInterrupts.cpp
+++ b/arch/x86/64/source/ArchInterrupts.cpp
@@ -168,6 +168,11 @@ extern TSS g_tss;
 
 extern "C" void arch_contextSwitch()
 {
+  if(outstanding_EOIs)
+  {
+          debug(A_INTERRUPTS, "%zu outstanding End-Of-Interrupt signal(s) on context switch. Probably called yield in the wrong place (e.g. in the scheduler)\n", outstanding_EOIs);
+          assert(!outstanding_EOIs);
+  }
   if (currentThread->switch_to_userspace_)
   {
     assert(currentThread->holding_lock_list_ == 0 && "Never switch to userspace when holding a lock! Never!");

--- a/arch/x86/64/source/ArchThreads.cpp
+++ b/arch/x86/64/source/ArchThreads.cpp
@@ -81,10 +81,7 @@ void ArchThreads::changeInstructionPointer(ArchThreadRegisters *info, void* func
 
 void ArchThreads::yield()
 {
-  __asm__ __volatile__("int $65"
-  :
-  :
-  );
+  __asm__ __volatile__("int $65");
 }
 
 size_t ArchThreads::testSetLock(size_t &lock, size_t new_value)

--- a/arch/x86/64/source/InterruptUtils.cpp
+++ b/arch/x86/64/source/InterruptUtils.cpp
@@ -29,6 +29,8 @@
 #include "paging-definitions.h"
 #include "PageFaultHandler.h"
 
+#include "8259.h"
+
 #define LO_WORD(x) (((uint32)(x)) & 0x0000FFFFULL)
 #define HI_WORD(x) ((((uint32)(x)) >> 16) & 0x0000FFFFULL)
 #define LO_DWORD(x) (((uint64)(x)) & 0x00000000FFFFFFFFULL)
@@ -161,6 +163,7 @@ extern Thread *currentThread;
 extern "C" void arch_irqHandler_0();
 extern "C" void irqHandler_0()
 {
+  ++outstanding_EOIs;
   ArchCommon::drawHeartBeat();
 
   Scheduler::instance()->incTicks();
@@ -195,6 +198,7 @@ extern "C" void pageFaultHandler(uint64 address, uint64 error)
 extern "C" void arch_irqHandler_1();
 extern "C" void irqHandler_1()
 {
+  ++outstanding_EOIs;
   KeyboardManager::instance()->serviceIRQ( );
   ArchInterrupts::EndOfInterrupt(1);
 }
@@ -203,6 +207,7 @@ extern "C" void arch_irqHandler_3();
 extern "C" void irqHandler_3()
 {
   kprintfd( "IRQ 3 called\n" );
+  ++outstanding_EOIs;
   SerialManager::getInstance()->service_irq( 3 );
   ArchInterrupts::EndOfInterrupt(3);
   kprintfd( "IRQ 3 ended\n" );
@@ -212,6 +217,7 @@ extern "C" void arch_irqHandler_4();
 extern "C" void irqHandler_4()
 {
   kprintfd( "IRQ 4 called\n" );
+  ++outstanding_EOIs;
   SerialManager::getInstance()->service_irq( 4 );
   ArchInterrupts::EndOfInterrupt(4);
   kprintfd( "IRQ 4 ended\n" );
@@ -228,6 +234,7 @@ extern "C" void arch_irqHandler_9();
 extern "C" void irqHandler_9()
 {
   kprintfd( "IRQ 9 called\n" );
+  ++outstanding_EOIs;
   BDManager::getInstance()->serviceIRQ( 9 );
   ArchInterrupts::EndOfInterrupt(9);
 }
@@ -236,6 +243,7 @@ extern "C" void arch_irqHandler_11();
 extern "C" void irqHandler_11()
 {
   kprintfd( "IRQ 11 called\n" );
+  ++outstanding_EOIs;
   BDManager::getInstance()->serviceIRQ( 11 );
   ArchInterrupts::EndOfInterrupt(11);
 }
@@ -244,6 +252,7 @@ extern "C" void arch_irqHandler_14();
 extern "C" void irqHandler_14()
 {
   //kprintfd( "IRQ 14 called\n" );
+  ++outstanding_EOIs;
   BDManager::getInstance()->serviceIRQ( 14 );
   ArchInterrupts::EndOfInterrupt(14);
 }
@@ -252,6 +261,7 @@ extern "C" void arch_irqHandler_15();
 extern "C" void irqHandler_15()
 {
   //kprintfd( "IRQ 15 called\n" );
+  ++outstanding_EOIs;
   BDManager::getInstance()->serviceIRQ( 15 );
   ArchInterrupts::EndOfInterrupt(15);
 }

--- a/arch/x86/common/include/8259.h
+++ b/arch/x86/common/include/8259.h
@@ -7,6 +7,8 @@
 #define PIC_1_DATA_PORT 0x21
 #define PIC_2_DATA_PORT 0xA1
 
+extern volatile size_t outstanding_EOIs;
+
 /**
  * sends the initialisation and operational command words to CPU
  *

--- a/arch/x86/common/source/8259.cpp
+++ b/arch/x86/common/source/8259.cpp
@@ -1,6 +1,8 @@
 #include "8259.h"
 #include "ports.h"
+#include "debug.h"
 
+volatile size_t outstanding_EOIs = 0;
 
 uint32 cached_mask = 0xFFFF;
 
@@ -22,6 +24,8 @@ void initialise8259s()
 
   for (i=0;i<16;++i)
     sendEOI(i);
+
+  outstanding_EOIs = 0;
 }
 
 void enableIRQ(uint16 number)
@@ -54,6 +58,8 @@ void disableIRQ(uint16 number)
 
 void sendEOI(uint16 number)
 {
+  --outstanding_EOIs;
+  debug(A_INTERRUPTS, "sendEOI, outstanding: %zu\n", outstanding_EOIs);
   if (number > 7)
     outportb(PIC_2_CONTROL_PORT,0x20);
 

--- a/common/source/kernel/Scheduler.cpp
+++ b/common/source/kernel/Scheduler.cpp
@@ -60,7 +60,9 @@ uint32 Scheduler::schedule()
   uint32 ret = 1;
 
   if (currentThread->switch_to_userspace_)
+  {
     currentThreadRegisters = currentThread->user_registers_;
+  }
   else
   {
     currentThreadRegisters = currentThread->kernel_registers_;


### PR DESCRIPTION
Catch errors caused by non-acknowledged 8259 interrupts.
Can be caused by e.g. calling yield()/currentThread->kill() in the scheduler. Leads to hard to trace errors such as the timer interrupt not triggering even though interrupts are enabled.
