### PR TITLE
Fix userspace/libc build for arch/x86/32/pae

### DIFF
--- a/userspace/libc/CMakeLists.txt
+++ b/userspace/libc/CMakeLists.txt
@@ -8,7 +8,13 @@ include_directories(
 
 
 set(LIBRARY_OUTPUT_PATH  "${LIBRARY_OUTPUT_PATH}/userspace")
-FILE(GLOB userspace_libc_SOURCES src/*.c ${CMAKE_SOURCE_DIR}/arch/${ARCH}/userspace/*.c ${CMAKE_SOURCE_DIR}/arch/${ARCH}/../common/userspace/*.c ${CMAKE_SOURCE_DIR}/arch/${ARCH}/common/userspace/*.c)
+FILE(GLOB userspace_libc_SOURCES
+    src/*.c
+    ${CMAKE_SOURCE_DIR}/arch/${ARCH}/userspace/*.c
+    ${CMAKE_SOURCE_DIR}/arch/${ARCH}/../../common/userspace/*.c
+    ${CMAKE_SOURCE_DIR}/arch/${ARCH}/../common/userspace/*.c
+    ${CMAKE_SOURCE_DIR}/arch/${ARCH}/common/userspace/*.c
+)
 
 ADD_LIBRARY(userspace_libc ${userspace_libc_SOURCES})
 


### PR DESCRIPTION
Previously, when building `x86/32/pae`, the `arch/x86/common/userspace` folder would not be considered, which could lead to linker errors.