### PR TITLE
Fixed Keyboard status light

### DIFF
--- a/arch/common/include/KeyboardManager.h
+++ b/arch/common/include/KeyboardManager.h
@@ -189,7 +189,7 @@ class KeyboardManager
      * writes a byte to the given IO port
      *
      */
-    void send_cmd(uint8 cmd, uint8 port = 0);
+    void send_cmd(uint8 cmd, uint8 port = 0x64);
 
     RingBuffer<uint8> keyboard_buffer_;
 
@@ -220,4 +220,3 @@ class KeyboardManager
 
     static KeyboardManager *instance_;
 };
-

--- a/arch/x86/common/source/KeyboardManager.cpp
+++ b/arch/x86/common/source/KeyboardManager.cpp
@@ -35,8 +35,6 @@ void KeyboardManager::kb_wait()
 
 void KeyboardManager::send_cmd(uint8 cmd, uint8 port)
 {
-  if(port == 0)
-    port = 0x64;
   kb_wait();
   outportbp(port, cmd);
 }

--- a/arch/x86/common/source/KeyboardManager.cpp
+++ b/arch/x86/common/source/KeyboardManager.cpp
@@ -35,7 +35,8 @@ void KeyboardManager::kb_wait()
 
 void KeyboardManager::send_cmd(uint8 cmd, uint8 port)
 {
-  port = 0x64;
+  if(port == 0)
+    port = 0x64;
   kb_wait();
   outportbp(port, cmd);
 }


### PR DESCRIPTION
Port is always set to 0x64 even if another port is given, keyboard LED change however sends cmd to 0x60.