### PR TITLE
Multiboot changes

### DIFF
--- a/arch/x86/64/source/ArchCommon.cpp
+++ b/arch/x86/64/source/ArchCommon.cpp
@@ -22,7 +22,7 @@ extern "C" void parseMultibootHeader()
   multiboot_info_t *mb_infos = *(multiboot_info_t**)VIRTUAL_TO_PHYSICAL_BOOT( (pointer)&multi_boot_structure_pointer);
   struct multiboot_remainder &orig_mbr = (struct multiboot_remainder &)(*((struct multiboot_remainder*)VIRTUAL_TO_PHYSICAL_BOOT((pointer)&mbr)));
 
-  if (mb_infos && mb_infos->flags & 1<<11)
+  if (mb_infos && mb_infos->f_vbe)
   {
     struct vbe_mode* mode_info = (struct vbe_mode*)(uint64)mb_infos->vbe_mode_info;
     orig_mbr.have_vesa_console = 1;
@@ -32,7 +32,7 @@ extern "C" void parseMultibootHeader()
     orig_mbr.vesa_bits_per_pixel = mode_info->bits_per_pixel;
   }
 
-  if (mb_infos && (mb_infos->flags & 1<<3))
+  if (mb_infos && mb_infos->f_mods)
   {
     module_t * mods = (module_t*)(uint64)mb_infos->mods_addr;
     for (i=0;i<mb_infos->mods_count;++i)
@@ -50,7 +50,7 @@ extern "C" void parseMultibootHeader()
     orig_mbr.memory_maps[i].used = 0;
   }
 
-  if (mb_infos && mb_infos->flags & 1<<6)
+  if (mb_infos && mb_infos->f_mmap)
   {
     uint32 mmap_size = sizeof(memory_map);
     uint32 mmap_total_size = mb_infos->mmap_length;

--- a/arch/x86/64/source/ArchCommon.cpp
+++ b/arch/x86/64/source/ArchCommon.cpp
@@ -52,17 +52,16 @@ extern "C" void parseMultibootHeader()
 
   if (mb_infos && mb_infos->f_mmap)
   {
-    uint32 mmap_size = sizeof(memory_map);
-    uint32 mmap_total_size = mb_infos->mmap_length;
-    uint32 num_maps = mmap_total_size / mmap_size;
+    uint32 num_maps = mb_infos->mmap_length / sizeof(memory_map);
 
     for (i=0;i<num_maps;++i)
     {
-      memory_map * map = (memory_map*)(uint64)(mb_infos->mmap_addr+mmap_size*i);
-      orig_mbr.memory_maps[i].used = 1;
-      orig_mbr.memory_maps[i].start_address = map->base_addr_low;
-      orig_mbr.memory_maps[i].end_address = map->base_addr_low + map->length_low;
-      orig_mbr.memory_maps[i].type = map->type;
+      memory_map * map = (memory_map*)(uint64)(mb_infos->mmap_addr + sizeof(memory_map)*i);
+      orig_mbr.memory_maps[i].used          = 1;
+      orig_mbr.memory_maps[i].start_address = ((uint64)map->base_addr_high << 32) | ((uint64)map->base_addr_low);
+      orig_mbr.memory_maps[i].end_address   = orig_mbr.memory_maps[i].start_address
+                                              + (((uint64)map->length_high << 32) | ((uint64)map->length_low));
+      orig_mbr.memory_maps[i].type          = map->type;
     }
   }
 }

--- a/arch/x86/64/source/ArchCommon.cpp
+++ b/arch/x86/64/source/ArchCommon.cpp
@@ -52,16 +52,18 @@ extern "C" void parseMultibootHeader()
 
   if (mb_infos && mb_infos->f_mmap)
   {
-    uint32 num_maps = mb_infos->mmap_length / sizeof(memory_map);
-
-    for (i=0;i<num_maps;++i)
+    size_t i = 0;
+    memory_map * map = (memory_map*)(uint64)(mb_infos->mmap_addr);
+    while((uint64)map < (uint64)(mb_infos->mmap_addr + mb_infos->mmap_length))
     {
-      memory_map * map = (memory_map*)(uint64)(mb_infos->mmap_addr + sizeof(memory_map)*i);
       orig_mbr.memory_maps[i].used          = 1;
       orig_mbr.memory_maps[i].start_address = ((uint64)map->base_addr_high << 32) | ((uint64)map->base_addr_low);
       orig_mbr.memory_maps[i].end_address   = orig_mbr.memory_maps[i].start_address
                                               + (((uint64)map->length_high << 32) | ((uint64)map->length_low));
       orig_mbr.memory_maps[i].type          = map->type;
+
+      map = (memory_map*)(((uint64)(map)) + map->size + sizeof(map->size));
+      ++i;
     }
   }
 }

--- a/arch/x86/common/include/multiboot.h
+++ b/arch/x86/common/include/multiboot.h
@@ -178,8 +178,8 @@ struct multiboot_remainder
   struct memory_maps
   {
     uint32 used;
-    uint32 start_address;
-    uint32 end_address;
+    uint64 start_address;
+    uint64 end_address;
     uint32 type;
   } __attribute__((__packed__)) memory_maps[MAX_MEMORY_MAPS];
 

--- a/arch/x86/common/include/multiboot.h
+++ b/arch/x86/common/include/multiboot.h
@@ -100,24 +100,44 @@ typedef struct elf_section_header_table
 
 typedef struct multiboot_info
 {
-  uint32 flags      : 32;
-  uint32 mem_lower    : 32;
-  uint32 mem_upper    : 32;
-  uint32 boot_device  : 32;
-  uint32 cmdline    : 32;
-  uint32 mods_count   : 32;
-  uint32 mods_addr    : 32;
+  union
+  {
+    uint32 flags            : 32;
+    struct
+    {
+      uint32 f_mem          : 1;  // 0
+      uint32 f_boot_dev     : 1;  // 1
+      uint32 f_cmdline      : 1;  // 2
+      uint32 f_mods         : 1;  // 3
+      uint32 f_aout_symtab  : 1;  // 4
+      uint32 f_elf_shdr     : 1;  // 5
+      uint32 f_mmap         : 1;  // 6
+      uint32 f_drives       : 1;  // 7
+      uint32 f_conf_tab     : 1;  // 8
+      uint32 f_bootl_name   : 1;  // 9
+      uint32 f_apm          : 1;  // 10
+      uint32 f_vbe          : 1;  // 11
+      uint32 f_fb           : 1;  // 12
+      uint32 f_other        : 19; // 13-31
+    } __attribute__((__packed__));
+  };
+  uint32 mem_lower          : 32;
+  uint32 mem_upper          : 32;
+  uint32 boot_device        : 32;
+  uint32 cmdline            : 32;
+  uint32 mods_count         : 32;
+  uint32 mods_addr          : 32;
   elf_section_header_table_t elf_sec;
-  uint32 mmap_length    : 32;
-  uint32 mmap_addr    : 32;
-  uint32 drives_length    : 32;
-  uint32 drives_addr    : 32;
-  uint32 config_table   : 32;
-  uint32 boot_loader_name : 32;
-  uint32 apm_table    : 32;
-  uint32 vbe_control_info : 32;
-  uint32 vbe_mode_info    : 32;
-  uint32 vbe_mode   : 32;
+  uint32 mmap_length        : 32;
+  uint32 mmap_addr          : 32;
+  uint32 drives_length      : 32;
+  uint32 drives_addr        : 32;
+  uint32 config_table       : 32;
+  uint32 boot_loader_name   : 32;
+  uint32 apm_table          : 32;
+  uint32 vbe_control_info   : 32;
+  uint32 vbe_mode_info      : 32;
+  uint32 vbe_mode           : 32;
   uint32 vbe_interface_seg  : 32;
   uint32 vbe_interface_off  : 32;
   uint32 vbe_interface_len  : 32;


### PR DESCRIPTION
* Multiboot mmap info
  * Read full 64-bit memory addresses
  * Use size field to iterate over structs (struct size is not guaranteed to be constant)
* Use a bitfield for the multiboot info flags
* Copy module names (32bit)
* Some debug output changes in PageManager