### PR TITLE
fix build for GCC 8

### DIFF
--- a/arch/x86/64/source/boot.32.C
+++ b/arch/x86/64/source/boot.32.C
@@ -11,7 +11,16 @@ asm(".equ PHYS_BASE,0xFFFFFFFF00000000");
 #define PRINT(X)
 #endif
 
-#define TRUNCATE(X) (char*)(((unsigned int)(((char*)X)+0x7FFFFFFF))+1) // virtual to physical address
+// virtual (linker VMA) address to physical (linker LMA) address
+// workaround for GCC 8
+#define TRUNCATE_A(X) (unsigned int)(((char*)X)+0x7FFFFFFF)
+#define TRUNCATE_B(X) (char*)(X+1)
+
+static inline char * truncate_b(volatile unsigned long truncate_a_res) {
+    return TRUNCATE_B(truncate_a_res);
+}
+
+#define TRUNCATE(X) truncate_b(TRUNCATE_A(X))
 
 #define MULTIBOOT_PAGE_ALIGN (1<<0)
 #define MULTIBOOT_MEMORY_INFO (1<<1)

--- a/common/include/ustl/sistream.h
+++ b/common/include/ustl/sistream.h
@@ -25,9 +25,9 @@ public:
 				istringstream (const void* p, size_type n) noexcept;
     explicit			istringstream (const cmemlink& source) noexcept;
     inline fmtflags		flags (void) const		{ return _flags; }
-    inline fmtflags		flags (fmtflags f)		{ fmtflags of (_flags); _flags = f; return of; }
-    inline fmtflags		setf (fmtflags f)		{ fmtflags of (_flags); _flags |= f; return of; }
-    inline fmtflags		unsetf (fmtflags f)		{ fmtflags of (_flags); _flags &= ~f; return of; }
+    inline fmtflags		flags (fmtflags f)		{ fmtflags of (_flags); _flags.f = f.f; return of; }
+    inline fmtflags		setf (fmtflags f)		{ fmtflags of (_flags); _flags.f |= f.f; return of; }
+    inline fmtflags		unsetf (fmtflags f)		{ fmtflags of (_flags); _flags.f &= ~f.f; return of; }
     inline fmtflags		setf (fmtflags f, fmtflags m)	{ unsetf(m); return setf(f); }
     inline void			iread (char& v)			{ v = skip_delimiters(); }
     inline void			iread (unsigned char& v)	{ char c; iread(c); v = c; }
@@ -47,14 +47,12 @@ public:
     /*inline void			iread (float& v)		{ double c; iread(c); v = c; }
     inline void			iread (long double& v)		{ double c; iread(c); v = c; }*/
     inline void			iread (fmtflags_bits f);
-    inline void			iread (unsigned long long& v)	{ long long c; iread(c); v = c; }
     /*void			iread (double& v);
     inline void			iread (float& v)		{ double c; iread(c); v = c; }
     inline void			iread (long double& v)		{ double c; iread(c); v = c; }*/
     void			iread (bool& v);
     void			iread (wchar_t& v);
     void			iread (string& v);
-    inline void			iread (fmtflags_bits f);
     inline string		str (void) const	{ string s; s.link (*this); return s; }
     inline istringstream&	str (const string& s)	{ link (s); return *this; }
     inline istringstream&	get (char& c)	{ return read (&c, sizeof(c)); }

--- a/common/include/ustl/sostream.h
+++ b/common/include/ustl/sostream.h
@@ -21,9 +21,9 @@ public:
 				ostringstream (const string& v = "");
 				ostringstream (void* p, size_t n) noexcept;
     inline fmtflags		flags (void) const		{ return _flags; }
-    inline fmtflags		flags (fmtflags f)		{ fmtflags of (_flags); _flags = f; return of; }
-    inline fmtflags		setf (fmtflags f)		{ fmtflags of (_flags); _flags |= f; return of; }
-    inline fmtflags		unsetf (fmtflags f)		{ fmtflags of (_flags); _flags &= ~f; return of; }
+    inline fmtflags		flags (fmtflags f)		{ fmtflags of (_flags); _flags.f = f.f; return of; }
+    inline fmtflags		setf (fmtflags f)		{ fmtflags of (_flags); _flags.f |= f.f; return of; }
+    inline fmtflags		unsetf (fmtflags f)		{ fmtflags of (_flags); _flags.f &= ~f.f; return of; }
     inline fmtflags		setf (fmtflags f, fmtflags m)	{ unsetf(m); return setf(f); }
     void			iwrite (unsigned char v);
     void			iwrite (wchar_t v);

--- a/common/include/ustl/uatomic.h
+++ b/common/include/ustl/uatomic.h
@@ -66,7 +66,6 @@ public:
     inline T		xor_fetch (T v, memory_order order = memory_order_seq_cst )
 			    { return __atomic_xor_fetch (&_v, v, order); }
     inline		operator T (void) const	{ return load(); }
-<<<<<<< HEAD
     inline T		operator= (T v)		{ store(v); return v; }
     inline T		operator++ (int)	{ return fetch_add (1); }
     inline T		operator-- (int)	{ return fetch_sub (1); }
@@ -77,18 +76,6 @@ public:
     inline T		operator&= (T v)	{ return and_fetch (v); }
     inline T		operator|= (T v)	{ return  or_fetch (v); }
     inline T		operator^= (T v)	{ return xor_fetch (v); }
-=======
-    inline atomic&	operator= (T v)		{ store(v); return *this; }
-    inline atomic	operator++ (int)	{ return fetch_add (1); }
-    inline atomic	operator-- (int)	{ return fetch_sub (1); }
-    inline atomic&	operator++ (void)	{ add_fetch (1); return *this; }
-    inline atomic&	operator-- (void)	{ sub_fetch (1); return *this; }
-    inline atomic&	operator+= (T v)	{ add_fetch (v); return *this; }
-    inline atomic&	operator-= (T v)	{ sub_fetch (v); return *this; }
-    inline atomic&	operator&= (T v)	{ and_fetch (v); return *this; }
-    inline atomic&	operator|= (T v)	{  or_fetch (v); return *this; }
-    inline atomic&	operator^= (T v)	{ xor_fetch (v); return *this; }
->>>>>>> original
 };
 #define ATOMIC_VAR_INIT	{0}
 

--- a/common/include/ustl/uios.h
+++ b/common/include/ustl/uios.h
@@ -70,7 +70,7 @@ public:
     enum { default_stream_buffer_size = 4095 };
 
     typedef uint32_t		openmode;	///< Holds openmode_bits.
-    typedef uint32_t		fmtflags;	///< Holds fmtflags_bits for a string stream.
+    struct fmtflags{ fmtflags(const uint32_t& flags) : f(flags){}; fmtflags() = default; uint32_t f; };	///< Holds fmtflags_bits for a string stream.
     typedef uint32_t		iostate;	///< Holds iostate_bits for a file stream.
     typedef file_exception	failure;	///< Thrown by fstream on errors.
 

--- a/common/source/ustl/sostream.cpp
+++ b/common/source/ustl/sostream.cpp
@@ -80,12 +80,12 @@ void ostringstream::fmtstring (char* fmt, const char* typestr, bool bInteger) co
 	    *fmt++ = '0';
 	fmt = encode_dec (fmt, _width);
     }
-    if (_flags & left)
+    if (_flags.f & left)
 	*fmt++ = '-';
     if (bInteger) {
-	if (_flags & showpos)
+	if (_flags.f & showpos)
 	    *fmt++ = '+';
-	if (_flags & showbase)
+	if (_flags.f & showbase)
 	    *fmt++ = '#';
     } else {
 	*fmt++ = '.';
@@ -94,11 +94,11 @@ void ostringstream::fmtstring (char* fmt, const char* typestr, bool bInteger) co
     while (*typestr)
 	*fmt++ = *typestr++;
     if (bInteger) {
-	if (_flags & hex)
-	    fmt[-1] = (_flags & uppercase) ? 'X' : 'x';
-	else if (_flags & oct)
+	if (_flags.f & hex)
+	    fmt[-1] = (_flags.f & uppercase) ? 'X' : 'x';
+	else if (_flags.f & oct)
 	    fmt[-1] = 'o';
-    } else if (_flags & scientific)
+    } else if (_flags.f & scientific)
 	fmt[-1] = 'E';
     *fmt = 0;
 }


### PR DESCRIPTION
We need `fmtflags` as a struct for the overloads not to conflict.

Also, some functions were defined twice