### PR TITLE
Fix TRUNCATE macro for -O1

### DIFF
--- a/arch/x86/64/source/boot.32.C
+++ b/arch/x86/64/source/boot.32.C
@@ -16,8 +16,8 @@ asm(".equ PHYS_BASE,0xFFFFFFFF00000000");
 #define TRUNCATE_A(X) (unsigned int)(((char*)X)+0x7FFFFFFF)
 #define TRUNCATE_B(X) (char*)(X+1)
 
-static inline char * truncate_b(unsigned long truncate_a_res) {
-    volatile unsigned long temp = truncate_a_res;
+static inline char * truncate_b(unsigned int truncate_a_res) {
+    volatile unsigned int temp = truncate_a_res;
     return TRUNCATE_B(temp);
 }
 

--- a/arch/x86/64/source/boot.32.C
+++ b/arch/x86/64/source/boot.32.C
@@ -16,8 +16,9 @@ asm(".equ PHYS_BASE,0xFFFFFFFF00000000");
 #define TRUNCATE_A(X) (unsigned int)(((char*)X)+0x7FFFFFFF)
 #define TRUNCATE_B(X) (char*)(X+1)
 
-static inline char * truncate_b(volatile unsigned long truncate_a_res) {
-    return TRUNCATE_B(truncate_a_res);
+static inline char * truncate_b(unsigned long truncate_a_res) {
+    volatile unsigned long temp = truncate_a_res;
+    return TRUNCATE_B(temp);
 }
 
 #define TRUNCATE(X) truncate_b(TRUNCATE_A(X))


### PR DESCRIPTION
The volatile qualifier is somehow ignored in function arguments, so I moved it to a variable.

Correctly compiles on -O1 (and incidentally also on -O2 and -O3).

[godbolt link](https://godbolt.org/g/rqgPhF)