### PR TITLE
Updated debug.h

### DIFF
--- a/common/include/console/debug.h
+++ b/common/include/console/debug.h
@@ -51,7 +51,7 @@ const size_t MAIN               = Ansi_Red     | OUTPUT_ENABLED;
 const size_t THREAD             = Ansi_Magenta | OUTPUT_ENABLED;
 const size_t USERPROCESS        = Ansi_Cyan    | OUTPUT_ENABLED;
 const size_t PROCESS_REG        = Ansi_Yellow  | OUTPUT_ENABLED;
-const size_t BACKTRACE          = Ansi_Red     | OUTPUT_ENABLED;
+const size_t BACKTRACE          = Ansi_Cyan    | OUTPUT_ENABLED;
 const size_t USERTRACE          = Ansi_Red     | OUTPUT_ENABLED;
 
 //group memory management


### PR DESCRIPTION
changed the debug message BACKTRACE from Ansi_Red to Ansi_Cyan.