### PR TITLE
Debug checks in VfsSyscall::dupChecking()

### DIFF
--- a/common/source/fs/VfsSyscall.cpp
+++ b/common/source/fs/VfsSyscall.cpp
@@ -40,6 +40,8 @@ FileDescriptor* VfsSyscall::getFileDescriptor(uint32 fd)
 int32 VfsSyscall::dupChecking(const char* pathname, Dentry*& pw_dentry, VfsMount*& pw_vfs_mount)
 {
   FileSystemInfo *fs_info = getcwd();
+  assert(fs_info != NULL);
+  assert(fs_info->pathname_.c_str() != NULL);
   if (pathname == 0)
     return -1;
 


### PR DESCRIPTION
`fs_info->pathname_.c_str()` can be `NULL` when the FileSystemInfo object
has already been destroyed (e.g. when copied incorrectly on fork).
Leads to hard-to-debug errors at `fs_info->pathname_ = "./";`