### PR TITLE
fix terminal selection

### DIFF
--- a/common/source/console/Console.cpp
+++ b/common/source/console/Console.cpp
@@ -29,7 +29,12 @@ void Console::handleKey(uint32 key)
 {
   KeyboardManager * km = KeyboardManager::instance();
 
-  uint32 terminal_selected = key - KEY_F1;
+  // the keycode for F1 is 0x80, while F2..F12 have keycodes 0x82..0x8e
+  uint32 terminal_selected = 0;
+  if (key == KEY_F1)
+    terminal_selected = 0;
+  else
+    terminal_selected = key - (KEY_F2 - 1);
 
   if (km->isShift())
   {


### PR DESCRIPTION
This commit allows the selection of terminal 2 (if multiple terminals are enabled).
Previously this was not possible, because there is a skipped keycode between F1 and F2 (F1 == 0x80, F2 == 0x82).