### PR TITLE
Keep status row on screen

### DIFF
--- a/common/source/console/TextConsole.cpp
+++ b/common/source/console/TextConsole.cpp
@@ -73,11 +73,15 @@ uint32 TextConsole::consoleSetCharacter(uint32 const &row, uint32 const&column, 
   return 0;
 }
 
+
+#define STAT_ROWS (1)
+
 void TextConsole::consoleScrollUp(uint8 const &state)
 {
   char* fb = (char*) ArchCommon::getFBPtr();
-  memcpy((void*) fb, (void*) (fb + (consoleGetNumColumns() * 2)),
-         (consoleGetNumRows() - 1) * consoleGetNumColumns() * 2);
+  memcpy((void*) (fb + (consoleGetNumColumns() * 2*STAT_ROWS)),
+         (void*) (fb + (consoleGetNumColumns() * 2*(STAT_ROWS+1))),
+         (consoleGetNumRows() - 1 + STAT_ROWS) * consoleGetNumColumns() * 2);
   for(size_t i = 0; i < consoleGetNumColumns(); i++)
   {
     fb[(i + (consoleGetNumRows() - 1) * consoleGetNumColumns()) * 2] = ' ';


### PR DESCRIPTION
Don't clear status row when scrolling the console. Prevents flickering and keeps the status row visible when printing lots of text.