### PR TITLE
ustl: include config.h so that HAVE_CPP* are correctly defined and fix exchange

### DIFF
--- a/common/include/ustl/ualgobase.h
+++ b/common/include/ustl/ualgobase.h
@@ -25,14 +25,6 @@ inline constexpr T&& forward (typename tm::RemoveReference<T>::Result&& v) noexc
 
 #if HAVE_CPP14
 template <typename T, typename U = T>
-auto exchange (T& a, U&& b)
-{
-    auto t = move(a);
-    a = forward<U>(b);
-    return t;
-}
-
-template <typename T, typename U = T>
 T exchange (T& a, U&& b)
 {
     T t = move(a);

--- a/common/include/ustl/utypes.h
+++ b/common/include/ustl/utypes.h
@@ -4,6 +4,7 @@
 // This file is free software, distributed under the MIT License.
 
 #pragma once
+#include "config.h"
 
 /*
 #define __STDC_LIMIT_MACROS // For WCHAR_MIN and WCHAR_MAX in stdint.


### PR DESCRIPTION
HAVE_CPP11 and HAVE_CPP14 are defined in config.h depending on compiler-provided defines to detect C++11 and C++14 support.

The current codebase never includes this header, and therefore assumes C++11 is not supported, meaning `ustl::unique_ptr`, `ustl::shared_ptr`, and other C++11 and later features cannot be used.

Including the header somehow also defines HAVE_CPP14 on new enough compilers, meaning the broken duplicate implementation of `ustl::exchange` needed to be fixed as well.

This fixes `ustl::unique_ptr` and `ustl::shared_ptr`.