### PR TITLE
armv8 ArchMemory unmapPage: missing "checkAndRemove" for page table level 1 entry

### DIFF
--- a/arch/armv8/common/source/ArchMemory.cpp
+++ b/arch/armv8/common/source/ArchMemory.cpp
@@ -42,6 +42,7 @@ bool ArchMemory::unmapPage(size_t virtual_page)
     if(empty)
     {
         PageManager::instance()->freePPN(m.level2_ppn);
+        empty = checkAndRemove<Level12TableEntry>((pointer)m.level1_entry, m.level1_index);
     }
 
     return true;


### PR DESCRIPTION
Added a missing "checkAndRemove" call in the armv8 unmapPage function, which lead to a possible double free.