### PR TITLE
Kernel memmove wrong way around

### DIFF
--- a/arch/armv8/common/source/ArchMemory.cpp
+++ b/arch/armv8/common/source/ArchMemory.cpp
@@ -42,6 +42,7 @@ bool ArchMemory::unmapPage(size_t virtual_page)
     if(empty)
     {
         PageManager::instance()->freePPN(m.level2_ppn);
+        empty = checkAndRemove<Level12TableEntry>((pointer)m.level1_entry, m.level1_index);
     }
 
     return true;

--- a/common/source/util/kstring.cpp
+++ b/common/source/util/kstring.cpp
@@ -45,9 +45,9 @@ extern "C" void *memmove(void *dest, const void *src, size_t length)
     return dest;
   }
 
-  if (src < dest)
+  if (src > dest)
   {
-    // if src is before dest we can do a forward copy
+    // if src is _not_ before dest we can do a forward copy
     while (length--)
     {
       *dest8++ = *src8++;
@@ -55,7 +55,7 @@ extern "C" void *memmove(void *dest, const void *src, size_t length)
   }
   else
   {
-    // if src is _not_ before dest we have to do a backward copy
+    // if src is before dest we have to do a backward copy
     src8 += length;
     dest8 += length;
 


### PR DESCRIPTION
Fixed wrong copy order of the kernel memmove which lead to problems with overlapping buffers.