### PR TITLE
memory leak in Loader::loadDebugInfoIfAvailable

### DIFF
--- a/common/source/kernel/Loader.cpp
+++ b/common/source/kernel/Loader.cpp
@@ -248,6 +248,8 @@ bool Loader::loadDebugInfoIfAvailable()
           }
         } else {
           debug(USERTRACE, "SWEBDbg Infos are empty\n");
+          delete[] stab_data;
+          delete[] stabstr_data;
           return false;
         }
       }


### PR DESCRIPTION
forgot to delete stab_data and stabstr_data when "SWEBDbg Infos are empty"