### PR TITLE
Include uvector.h in uqueue.h

### DIFF
--- a/common/include/ustl/uqueue.h
+++ b/common/include/ustl/uqueue.h
@@ -4,6 +4,7 @@
 // This file is free software, distributed under the MIT License.
 
 #pragma once
+#include "uvector.h"
 
 namespace ustl {
 


### PR DESCRIPTION
Currently, compilation fails with the error `uqueue.h:15:44: error: ‘vector’ does not name a type
 template <typename T, typename Container = vector<T> >` when only the file `uqueue.h` without `uvector.h` is included.