### PR TITLE
itoa now correctly converts with base 16

### DIFF
--- a/common/source/util/kstring.cpp
+++ b/common/source/util/kstring.cpp
@@ -487,7 +487,7 @@ extern "C" char numToASCIIChar(uint8 number)
     return 0x30 + number;
 
   if (number >= 0xa && number <= 0xf)
-    return 0x61 + number;
+    return 0x61 + number - 0xa;
 
   // default value
   return '?';


### PR DESCRIPTION
Calls to `itoa` https://github.com/IAIK/sweb/blob/a559148a2c6cba69f88ce0043736b8cec2059252/common/source/util/kstring.cpp#L496 with base 16 printed strange, non-hex characters. 