### PR TITLE
Vfs flag fixes

### DIFF
--- a/common/include/fs/File.h
+++ b/common/include/fs/File.h
@@ -10,6 +10,13 @@ class Dentry;
 #define O_WRONLY    0x0001
 #define O_RDWR      0x0002
 #define O_CREAT     0x0004
+#define O_APPEND    0x0010
+#define O_EXCL      0x0020
+#define O_NONBLOCK  0x0040
+#define O_TRUNC     0x0080
+#define O_SYNC      0x0100
+#define O_DSYNC     0x0200
+#define O_RSYNC     O_SYNC
 
 #define A_READABLE  0x0001
 #define A_WRITABLE  0x0002

--- a/common/include/fs/File.h
+++ b/common/include/fs/File.h
@@ -18,10 +18,6 @@ class Dentry;
 #define O_DSYNC     0x0200
 #define O_RSYNC     O_SYNC
 
-#define A_READABLE  0x0001
-#define A_WRITABLE  0x0002
-#define A_EXECABLE  0x0004
-
 #ifndef SEEK_SET
 #define SEEK_SET 0
 #endif
@@ -36,7 +32,7 @@ class File
 {
   public:
 
-    typedef uint32 mode_t;
+    //typedef uint32 mode_t;
 
     class Owner
     {
@@ -72,11 +68,6 @@ class File
      */
     uint32 flag_;
 
-    /**
-     * The process access mode of the file;
-     * default value: READABLE ^ WRITABLE ^ EXECABLE
-     */
-    mode_t mode_;
 
     /**
      * Current offset in the file

--- a/common/include/fs/File.h
+++ b/common/include/fs/File.h
@@ -6,10 +6,10 @@ class Superblock;
 class Inode;
 class Dentry;
 
-#define O_RDONLY    0x0000
-#define O_WRONLY    0x0001
-#define O_RDWR      0x0002
-#define O_CREAT     0x0004
+#define O_RDONLY    0x0001
+#define O_WRONLY    0x0002
+#define O_RDWR      0x0004
+#define O_CREAT     0x0008
 #define O_APPEND    0x0010
 #define O_EXCL      0x0020
 #define O_NONBLOCK  0x0040

--- a/common/include/fs/File.h
+++ b/common/include/fs/File.h
@@ -32,8 +32,6 @@ class File
 {
   public:
 
-    //typedef uint32 mode_t;
-
     class Owner
     {
     };

--- a/common/include/fs/Inode.h
+++ b/common/include/fs/Inode.h
@@ -16,6 +16,10 @@ class Superblock;
 // will be written next time a sync is requested.
 #define I_LOCK 2  //state not implemented
 
+#define A_READABLE  0x0001
+#define A_WRITABLE  0x0002
+#define A_EXECABLE  0x0004
+
 /**
  * five possible inode type bits:
  */
@@ -64,7 +68,11 @@ class Inode
      * There are three possible inode state bits: I_DIRTY, I_LOCK, I_UNUSED.
      */
     uint32 i_state_;
-
+     
+    /**
+     * The inodes permission flag
+     */
+    uint32 i_mode_;
   public:
 
     /**
@@ -76,6 +84,7 @@ class Inode
         i_dentry_(0), i_nlink_(0), i_size_(0), i_state_(I_UNUSED)
     {
       superblock_ = super_block, i_type_ = inode_type;
+      i_mode_ = (A_READABLE ^ A_WRITABLE) ^ A_EXECABLE;
     }
 
     virtual ~Inode()
@@ -307,6 +316,11 @@ class Inode
     uint32 getSize()
     {
       return i_size_;
+    }
+
+    uint32 getMode()
+    {
+      return i_mode_;
     }
 
     int32 flush()

--- a/common/source/fs/VfsSyscall.cpp
+++ b/common/source/fs/VfsSyscall.cpp
@@ -274,7 +274,7 @@ int32 VfsSyscall::close(uint32 fd)
 int32 VfsSyscall::open(const char* pathname, uint32 flag)
 {
   FileSystemInfo *fs_info = getcwd();
-  if (flag > (O_CREAT | O_RDWR))
+  if (flag & ~(O_RDONLY | O_WRONLY | O_CREAT | O_RDWR | O_TRUNC | O_APPEND))
   {
     debug(VFSSYSCALL, "(open) invalid parameter flag\n");
     return -1;

--- a/common/source/fs/VfsSyscall.cpp
+++ b/common/source/fs/VfsSyscall.cpp
@@ -279,6 +279,11 @@ int32 VfsSyscall::open(const char* pathname, uint32 flag)
     debug(VFSSYSCALL, "(open) invalid parameter flag\n");
     return -1;
   }
+  if(flag & (O_APPEND | O_TRUNC))
+  {
+    debug(VFSSYSCALL, "(open) not yet implemented\n");
+    return -1;
+  }
   Dentry* pw_dentry = 0;
   VfsMount* pw_vfs_mount = 0;
   if (dupChecking(pathname, pw_dentry, pw_vfs_mount) == 0)

--- a/common/source/fs/VfsSyscall.cpp
+++ b/common/source/fs/VfsSyscall.cpp
@@ -281,7 +281,7 @@ int32 VfsSyscall::open(const char* pathname, uint32 flag)
   }
   if(flag & (O_APPEND | O_TRUNC))
   {
-    debug(VFSSYSCALL, "(open) not yet implemented\n");
+    kprintfd("(open) flags not yet implemented\n");
     return -1;
   }
   Dentry* pw_dentry = 0;

--- a/common/source/fs/VfsSyscall.cpp
+++ b/common/source/fs/VfsSyscall.cpp
@@ -299,7 +299,7 @@ int32 VfsSyscall::open(const char* pathname, uint32 flag)
       return -1;
     }
 
-    int32 fd = current_sb->createFd(current_inode, flag & 0xFFFFFFFB);
+    int32 fd = current_sb->createFd(current_inode, flag);
     debug(VFSSYSCALL, "the fd-num: %d, flag: %d\n", fd, flag);
 
     return fd;
@@ -344,7 +344,7 @@ int32 VfsSyscall::open(const char* pathname, uint32 flag)
     }
     debug(VFSSYSCALL, "(open) created Inode with dentry name %s\n", sub_inode->getDentry()->getName());
 
-    int32 fd = current_sb->createFd(sub_inode, flag & 0xFFFFFFFB);
+    int32 fd = current_sb->createFd(sub_inode, flag);
     debug(VFSSYSCALL, "the fd-num: %d\n", fd);
 
     return fd;

--- a/common/source/fs/minixfs/MinixFSFile.cpp
+++ b/common/source/fs/minixfs/MinixFSFile.cpp
@@ -8,7 +8,7 @@ MinixFSFile::MinixFSFile(Inode* inode, Dentry* dentry, uint32 flag) :
   f_superblock_ = inode->getSuperblock();
   // to get the real mode implement it in the inode constructor and get it from there
   // if you do so implement chmod and createInode with mode
-  mode_ = (A_READABLE ^ A_WRITABLE) ^ A_EXECABLE;
+  //mode_ = (A_READABLE ^ A_WRITABLE) ^ A_EXECABLE;
   offset_ = 0;
 }
 
@@ -18,7 +18,7 @@ MinixFSFile::~MinixFSFile()
 
 int32 MinixFSFile::read(char *buffer, size_t count, l_off_t offset)
 {
-  if (((flag_ == O_RDONLY) || (flag_ == O_RDWR)) && (mode_ & A_READABLE))
+  if (((flag_ == O_RDONLY) || (flag_ == O_RDWR)) && (f_inode_->getMode() & A_READABLE))
   {
     int32 read_bytes = f_inode_->readData(offset_ + offset, count, buffer);
     offset_ += read_bytes;
@@ -33,7 +33,7 @@ int32 MinixFSFile::read(char *buffer, size_t count, l_off_t offset)
 
 int32 MinixFSFile::write(const char *buffer, size_t count, l_off_t offset)
 {
-  if (((flag_ == O_WRONLY) || (flag_ == O_RDWR)) && (mode_ & A_WRITABLE))
+  if (((flag_ == O_WRONLY) || (flag_ == O_RDWR)) && (f_inode_->getMode() & A_WRITABLE))
   {
     int32 written = f_inode_->writeData(offset_ + offset, count, buffer);
     offset_ += written;

--- a/common/source/fs/minixfs/MinixFSFile.cpp
+++ b/common/source/fs/minixfs/MinixFSFile.cpp
@@ -6,9 +6,6 @@ MinixFSFile::MinixFSFile(Inode* inode, Dentry* dentry, uint32 flag) :
     File(inode, dentry, flag)
 {
   f_superblock_ = inode->getSuperblock();
-  // to get the real mode implement it in the inode constructor and get it from there
-  // if you do so implement chmod and createInode with mode
-  //mode_ = (A_READABLE ^ A_WRITABLE) ^ A_EXECABLE;
   offset_ = 0;
 }
 

--- a/common/source/fs/minixfs/MinixFSFile.cpp
+++ b/common/source/fs/minixfs/MinixFSFile.cpp
@@ -15,7 +15,7 @@ MinixFSFile::~MinixFSFile()
 
 int32 MinixFSFile::read(char *buffer, size_t count, l_off_t offset)
 {
-  if (((flag_ == O_RDONLY) || (flag_ == O_RDWR)) && (f_inode_->getMode() & A_READABLE))
+  if (((flag_ & O_RDONLY) || (flag_ & O_RDWR)) && (f_inode_->getMode() & A_READABLE))
   {
     int32 read_bytes = f_inode_->readData(offset_ + offset, count, buffer);
     offset_ += read_bytes;
@@ -30,7 +30,7 @@ int32 MinixFSFile::read(char *buffer, size_t count, l_off_t offset)
 
 int32 MinixFSFile::write(const char *buffer, size_t count, l_off_t offset)
 {
-  if (((flag_ == O_WRONLY) || (flag_ == O_RDWR)) && (f_inode_->getMode() & A_WRITABLE))
+  if (((flag_ & O_WRONLY) || (flag_ & O_RDWR)) && (f_inode_->getMode() & A_WRITABLE))
   {
     int32 written = f_inode_->writeData(offset_ + offset, count, buffer);
     offset_ += written;

--- a/common/source/fs/ramfs/RamFSFile.cpp
+++ b/common/source/fs/ramfs/RamFSFile.cpp
@@ -11,7 +11,6 @@ RamFSFile::RamFSFile(Inode* inode, Dentry* dentry, uint32 flag) :
     File(inode, dentry, flag)
 {
   f_superblock_ = inode->getSuperblock();
-  mode_ = ( A_READABLE ^ A_WRITABLE) ^ A_EXECABLE;
   offset_ = 0;
 }
 
@@ -21,7 +20,7 @@ RamFSFile::~RamFSFile()
 
 int32 RamFSFile::read(char *buffer, size_t count, l_off_t offset)
 {
-  if (((flag_ == O_RDONLY) || (flag_ == O_RDWR)) && (mode_ & A_READABLE))
+  if (((flag_ == O_RDONLY) || (flag_ == O_RDWR)) && (f_inode_->getMode() & A_READABLE))
   {
     int32 read_bytes = f_inode_->readData(offset_ + offset, count, buffer);
     offset_ += read_bytes;
@@ -36,7 +35,7 @@ int32 RamFSFile::read(char *buffer, size_t count, l_off_t offset)
 
 int32 RamFSFile::write(const char *buffer, size_t count, l_off_t offset)
 {
-  if (((flag_ == O_WRONLY) || (flag_ == O_RDWR)) && (mode_ & A_WRITABLE))
+  if (((flag_ == O_WRONLY) || (flag_ == O_RDWR)) && (f_inode_->getMode() & A_WRITABLE))
   {
     int32 written_bytes = f_inode_->writeData(offset_ + offset, count, buffer);
     offset_ += written_bytes;

--- a/common/source/fs/ramfs/RamFSFile.cpp
+++ b/common/source/fs/ramfs/RamFSFile.cpp
@@ -20,7 +20,7 @@ RamFSFile::~RamFSFile()
 
 int32 RamFSFile::read(char *buffer, size_t count, l_off_t offset)
 {
-  if (((flag_ == O_RDONLY) || (flag_ == O_RDWR)) && (f_inode_->getMode() & A_READABLE))
+  if (((flag_ & O_RDONLY) || (flag_ & O_RDWR)) && (f_inode_->getMode() & A_READABLE))
   {
     int32 read_bytes = f_inode_->readData(offset_ + offset, count, buffer);
     offset_ += read_bytes;
@@ -35,7 +35,7 @@ int32 RamFSFile::read(char *buffer, size_t count, l_off_t offset)
 
 int32 RamFSFile::write(const char *buffer, size_t count, l_off_t offset)
 {
-  if (((flag_ == O_WRONLY) || (flag_ == O_RDWR)) && (f_inode_->getMode() & A_WRITABLE))
+  if (((flag_ & O_WRONLY) || (flag_ & O_RDWR)) && (f_inode_->getMode() & A_WRITABLE))
   {
     int32 written_bytes = f_inode_->writeData(offset_ + offset, count, buffer);
     offset_ += written_bytes;

--- a/userspace/libc/include/fcntl.h
+++ b/userspace/libc/include/fcntl.h
@@ -41,22 +41,22 @@ extern "C" {
 #define O_CREAT     0x0004
 #endif
 #ifndef O_APPEND
-#define O_APPEND    0x0008
+#define O_APPEND    0x0010
 #endif
 #ifndef O_EXCL
-#define O_EXCL      0x0010
+#define O_EXCL      0x0020
 #endif
 #ifndef O_NONBLOCK
-#define O_NONBLOCK  0x0020
+#define O_NONBLOCK  0x0040
 #endif
 #ifndef O_TRUNC
-#define O_TRUNC     0x0040
+#define O_TRUNC     0x0080
 #endif
 #ifndef O_SYNC
-#define O_SYNC      0x0080
+#define O_SYNC      0x0100
 #endif
 #ifndef O_DSYNC
-#define O_DSYNC     0x0100
+#define O_DSYNC     0x0200
 #endif
 #ifndef O_RSYNC
 #define O_RSYNC     O_SYNC

--- a/userspace/libc/include/fcntl.h
+++ b/userspace/libc/include/fcntl.h
@@ -29,16 +29,16 @@ extern "C" {
  * The basic flags for files
  */
 #ifndef O_RDONLY
-#define O_RDONLY    0x0000
+#define O_RDONLY    0x0001
 #endif
 #ifndef O_WRONLY
-#define O_WRONLY    0x0001
+#define O_WRONLY    0x0002
 #endif
 #ifndef O_RDWR
-#define O_RDWR      0x0002
+#define O_RDWR      0x0004
 #endif
 #ifndef O_CREAT
-#define O_CREAT     0x0004
+#define O_CREAT     0x0008
 #endif
 #ifndef O_APPEND
 #define O_APPEND    0x0010

--- a/utils/exe2minixfs/exe2minixfs.cpp
+++ b/utils/exe2minixfs/exe2minixfs.cpp
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
     fclose(src_file);
 
     VfsSyscall::rm(argv[2 * i]);
-    int32 fd = VfsSyscall::open(argv[2 * i], 2 | 4);
+    int32 fd = VfsSyscall::open(argv[2 * i], 4 | 8); // i.e. O_RDWR | O_CREAT
     if (fd < 0)
     {
       printf("no success\n");


### PR DESCRIPTION
This PR adds a correct flag check for `VfsSyscall::open`. It now compares with existing flags instead of checking whether the passed flag exceeded a constant. This also adds a NYI error for the flags `O_TRUNC` and `O_APPEND`.

The file open `#define`s now match between user- and kernelspace.

This also moves the files fs permissions (i.e. `i_mode_`) from `File.h` to `Inode.h`.