### PR TITLE
net and net-init targets for x86_64

### DIFF
--- a/arch/x86/64/CMakeLists.include
+++ b/arch/x86/64/CMakeLists.include
@@ -75,14 +75,6 @@ add_custom_target(qemutacos
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
   )
 
-# net: Run qemu with network support, make sure to run after target "net-init"
-add_custom_target(net
-  COMMAND sudo ${QEMU_BIN} ${QEMU_FLAGS_COMMON} -netdev bridge,id=hn0 -device rtl8139,netdev=hn0,id=nic1 -cpu qemu64
-  COMMENT "Executing `sudo ${QEMU_BIN} ${QEMU_FLAGS_COMMON_STR} -netdev bridge,id=hn0 -device rtl8139,netdev=hn0,id=nic1 -cpu qemu64`"
-  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-  COMMAND reset -I
-  )
-
 # net-init: Initializes br0 for target "net"
 add_custom_target(net-init
   COMMAND sudo ${PROJECT_SOURCE_DIR}/utils/netinit.sh

--- a/arch/x86/64/CMakeLists.include
+++ b/arch/x86/64/CMakeLists.include
@@ -75,4 +75,18 @@ add_custom_target(qemutacos
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
   )
 
+# net: Run qemu with network support, make sure to run after target "net-init"
+add_custom_target(net
+  COMMAND sudo ${QEMU_BIN} ${QEMU_FLAGS_COMMON} -netdev bridge,id=hn0 -device rtl8139,netdev=hn0,id=nic1 -cpu qemu64
+  COMMENT "Executing `sudo ${QEMU_BIN} ${QEMU_FLAGS_COMMON_STR} -netdev bridge,id=hn0 -device rtl8139,netdev=hn0,id=nic1 -cpu qemu64`"
+  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+  COMMAND reset -I
+  )
 
+# net-init: Initializes br0 for target "net"
+add_custom_target(net-init
+  COMMAND sudo ${PROJECT_SOURCE_DIR}/utils/netinit.sh
+  COMMENT "Executing `sudo utils/netinit.sh`"
+  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+  COMMAND reset -I
+  )


### PR DESCRIPTION
This adds two missing target, `net` and `net-init` to the x86_64 Makefile.