### PR TITLE
ustl: fix in umemory.h to prevent compile errors when shared pointers…

### DIFF
--- a/common/include/ustl/umemory.h
+++ b/common/include/ustl/umemory.h
@@ -173,7 +173,7 @@ private:
 public:
     inline constexpr		shared_ptr (void)		: _p (nullptr) {}
     inline explicit		shared_ptr (pointer p)		: _p (new container (p)) {}
-    inline			shared_ptr (shared_ptr&& p)	: _p (exchange (p._p, nullptr)) {}
+    inline			shared_ptr (shared_ptr&& p)	: _p (p._p) { p._p = nullptr; }
     inline			shared_ptr (const shared_ptr& p): _p (p._p) { if (_p) ++_p->refs; }
     inline			~shared_ptr (void)		{ reset(); }
     inline constexpr size_t	use_count (void) const		{ return _p ? _p->refs : 0; }
@@ -478,7 +478,7 @@ ForwardIterator uninitialized_fill_n (ForwardIterator first, size_t n, const T& 
 }
 
 #if HAVE_CPP11
-    
+
 /// Moves [first, last) into result by calling move constructors in result.
 /// \ingroup RawStorageAlgorithms
 ///


### PR DESCRIPTION
… are used

see https://github.com/msharov/ustl/commit/44ee433576e013fa1de6ea3e7c1a79aa5b914978