### PR TITLE
Fix printf for strings >256 chars

### DIFF
--- a/userspace/libc/src/printf.c
+++ b/userspace/libc/src/printf.c
@@ -522,7 +522,7 @@ extern int printf(const char *format, ...)
           int len = strlen(string_arg);
 
           // we should align right -> fill with spaces
-          if( !((flag & LEFT) && (len < width)) )
+          if( !(flag & LEFT) && (len < width) )
           {
             character_count -= width - len;
             if( character_count < 0 )


### PR DESCRIPTION
Fixes #201 

Due to a negation mistake in the right-align code, character_count sometimes got increased to over 256 by a subtraction of negative numbers.

printf now correctly truncates.