### PR TITLE
Fix use-after-free in KMM

### DIFF
--- a/common/source/mm/KernelMemoryManager.cpp
+++ b/common/source/mm/KernelMemoryManager.cpp
@@ -101,7 +101,7 @@ bool KernelMemoryManager::freeMemory(pointer virtual_address, pointer called_by)
     return false;
   }
   freeSegment(m_segment);
-  if (m_segment->markerOk())
+  if ((pointer)m_segment < kernel_break_ && m_segment->markerOk())
     m_segment->freed_at_ = called_by;
 
   unlockKMM();
@@ -171,7 +171,7 @@ pointer KernelMemoryManager::reallocateMemory(pointer virtual_address, size_t ne
     }
     memcpy((void*) new_address, (void*) virtual_address, m_segment->getSize());
     freeSegment(m_segment);
-    if (m_segment->markerOk())
+    if ((pointer)m_segment < kernel_break_ && m_segment->markerOk())
       m_segment->freed_at_ = called_by;
     unlockKMM();
     return new_address;


### PR DESCRIPTION
use the following (e.g. in main.cpp) to reproduce the bug:
```
auto kmm = KernelMemoryManager::instance();
pointer p1 = kmm->allocateMemory(PAGE_SIZE*2, 0);
pointer p2 = kmm->allocateMemory(PAGE_SIZE*2, 0);
kmm->freeMemory(p1, 0);
kmm->freeMemory(p2, 0);
```
from the commit:
> When enabling the DYNAMIC_KMM, a call to the freeSegment method
> possibly removes the page, where the KMM saved the segment.
> Any further access may lead to a page fault and subsequently to
> a kernel panic.
> 
> For example, allocating two buffers (p1and p2) of at least the
> size of PAGE_SIZE allocates at least two pages (assuming no
> memory on the heap is free).
> Freeing p1 does nothing because memory after p1 is not free.
> Then freeing p2 leads to a call to ksbrk that unmaps the page of
> p2, including its MallocSegment, and then the page of p1.
> Further accesses to the MallocSegment of p2 fail and lead to a
> panic.
> 
> The ksbrk method sets the kernel_break_, that a check can use to
> see if heap-memory can be accessed safely.