### PR TITLE
Use-after-free detection for PPNs

### DIFF
--- a/arch/x86/32/common/source/InterruptUtils.cpp
+++ b/arch/x86/32/common/source/InterruptUtils.cpp
@@ -140,6 +140,7 @@ extern "C" void irqHandler_65()
 extern "C" void arch_pageFaultHandler();
 extern "C" void pageFaultHandler(uint32 address, uint32 error)
 {
+  assert(!(error & FLAG_PF_RSVD) && "Reserved bit set in page table entry");
   PageFaultHandler::enterPageFault(address, error & FLAG_PF_USER,
                                    error & FLAG_PF_PRESENT,
                                    error & FLAG_PF_RDWR,

--- a/arch/x86/64/source/InterruptUtils.cpp
+++ b/arch/x86/64/source/InterruptUtils.cpp
@@ -185,6 +185,7 @@ extern "C" void irqHandler_65()
 extern "C" void arch_pageFaultHandler();
 extern "C" void pageFaultHandler(uint64 address, uint64 error)
 {
+  assert(!(error & FLAG_PF_RSVD) && "Reserved bit set in page table entry");
   PageFaultHandler::enterPageFault(address, error & FLAG_PF_USER,
                                    error & FLAG_PF_PRESENT,
                                    error & FLAG_PF_RDWR,

--- a/common/include/util/kstring.h
+++ b/common/include/util/kstring.h
@@ -35,6 +35,7 @@ extern "C"
   int32 memcmp(const void *region1, const void *region2, size_t size);
   int32 strcmp(const char *str1, const char *str2);
   int32 strncmp(const char *str1, const char *str2, size_t n);
+  void *memnotchr(const void *block, uint8 c, size_t size);
   void *memchr(const void *block, uint8 c, size_t size);
   void *memrchr(const void *block, uint8 c, size_t size);
   char *strchr(const char* str, char c);

--- a/common/source/util/kstring.cpp
+++ b/common/source/util/kstring.cpp
@@ -342,6 +342,22 @@ extern "C" int32 bcmp(const void *region1, const void *region2, size_t size)
   return 0;
 }
 
+extern "C" void *memnotchr(const void *block, uint8 c, size_t size)
+{
+  const uint8 *b = (const uint8*) block;
+
+  while (size--)
+  {
+    if (*b != c)
+    {
+      return (void *) b;
+    }
+    ++b;
+  }
+
+  return (void *) 0;
+}
+
 extern "C" void *memchr(const void *block, uint8 c, size_t size)
 {
   const uint8 *b = (const uint8*) block;


### PR DESCRIPTION
\+ detect page faults caused by invalid use of reserved bits