### PR TITLE
add locking checks for mutex

### DIFF
--- a/common/source/kernel/Mutex.cpp
+++ b/common/source/kernel/Mutex.cpp
@@ -60,6 +60,9 @@ void Mutex::acquire(pointer called_by)
 //    debug(LOCK, "The acquire is called by: ");
 //    kernel_debug_info->printCallInformation(called_by);
 //  }
+  // check for deadlocks, interrupts...
+  doChecksBeforeWaiting();
+
   while(ArchThreads::testSetLock(mutex_, 1))
   {
     checkCurrentThreadStillWaitingOnAnotherLock();


### PR DESCRIPTION
Add locking checks for acquiring a mutex for the case where we don't need to sleep.