### PR TITLE
Add copy constructor for Bitmap utility class

### DIFF
--- a/common/include/util/Bitmap.h
+++ b/common/include/util/Bitmap.h
@@ -11,6 +11,7 @@ class Bitmap
     static uint8 const bits_per_bitmap_atom_;
 
     Bitmap(size_t number_of_bits);
+    Bitmap(const Bitmap &bm);
     ~Bitmap();
 
     bool setBit(size_t bit_number);

--- a/common/source/util/Bitmap.cpp
+++ b/common/source/util/Bitmap.cpp
@@ -1,6 +1,7 @@
 #include "Bitmap.h"
 #include "kprintf.h"
 #include "assert.h"
+#include "kstring.h"
 
 uint8 const Bitmap::bits_per_bitmap_atom_ = 8;
 
@@ -20,6 +21,15 @@ Bitmap::Bitmap(size_t number_of_bits) :
         num_bits_set_(0)
 {
   bitmap_ = new uint8[BITMAP_BYTE_COUNT(number_of_bits)]{};
+}
+
+Bitmap::Bitmap(const Bitmap &bm)
+  : size_(bm.size_)
+  , num_bits_set_(bm.num_bits_set_)
+{
+  const size_t bytes = BITMAP_BYTE_COUNT(size_);
+  bitmap_ = new uint8[bytes]{};
+  memcpy(bitmap_, bm.bitmap_, bytes);
 }
 
 Bitmap::~Bitmap()


### PR DESCRIPTION
Add copy constructor that does a deep copy of the bitmap. This will probably save a few future OS students some debugging time :)