### PR TITLE
Resize disk image to next power of two + error check for arm verdex build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,10 +180,18 @@ endforeach(file)
 
 #Custom Target: hdd_image
 #Creates the hd image and copies all files to it
-add_custom_target (hdd_image ALL
+add_custom_target (hdd_image_pre_resize ALL
   DEPENDS kernel_to_image userspace_to_image
   COMMAND qemu-img convert -f raw -O qcow2 ${HDD_IMAGE_RAW} ${HDD_IMAGE}
-)
+  # COMMAND bash -c "qemu-img resize ${HDD_IMAGE} $(echo "x=l($(qemu-img info SWEB.qcow2 | sed -n -e 's|virtual size: .* (\(.*\) bytes)|\1|p'))/l(2); scale=0; 2^((x+0.5)/1)" | bc -l)"
+  # VERBATIM
+  )
+
+# Resize hdd image to next power of two (required when used as an sd card)
+add_custom_target (hdd_image ALL
+  DEPENDS hdd_image_pre_resize
+  COMMAND ${CMAKE_SOURCE_DIR}/utils/images/resize_power2.sh "${PROJECT_BINARY_DIR}/${HDD_IMAGE}"
+  )
 
 #Custom Command: invoke exe2minixfs and copy boot files to our hd image
 add_custom_target (kernel_to_image

--- a/arch/arm/verdex/utils/makeflash.sh
+++ b/arch/arm/verdex/utils/makeflash.sh
@@ -1,10 +1,20 @@
-#!/bin/bash
-mkimage -A arm -O linux -T kernel -a 0xA0000000 -e 0xA0001000 -C none -n "SWEB ARM Gumstix Verdex kernel.x" -d kernel.x kernel.img
-if [[ "$?" != "0" ]]; then
-  echo "Consider installing u-boot-tools"
-  exit -1
-fi
-dd of=flash.img bs=128k count=256 if=/dev/zero
-dd of=flash.img bs=128k conv=notrunc if=$1
-dd of=flash.img bs=128k conv=notrunc seek=248 if=kernel.img
+#!/usr/bin/env sh
 
+FLASH_IMAGE=flash.img
+KERNEL_BIN=kernel.x
+KERNEL_IMAGE=kernel.img
+
+mkimage -A arm -O linux -T kernel -a 0xA0000000 -e 0xA0001000 -C none -n "SWEB ARM Gumstix Verdex kernel.x" -d ${KERNEL_BIN} ${KERNEL_IMAGE}
+if [ "$?" != "0" ]; then
+  echo "Consider installing u-boot-tools"
+  exit 1
+fi
+
+if [ -n "$(find "${KERNEL_IMAGE}" -prune -size +1000000c)" ]; then
+    echo "ERROR: Kernel image is too large for arm verdex flash (max 1Mib)"
+    exit 1
+fi
+
+dd of=${FLASH_IMAGE} bs=128k count=256 if=/dev/zero
+dd of=${FLASH_IMAGE} bs=128k conv=notrunc if=$1
+dd of=${FLASH_IMAGE} bs=128k conv=notrunc seek=248 if=${KERNEL_IMAGE}

--- a/utils/images/resize_power2.sh
+++ b/utils/images/resize_power2.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+set -e
+
+IMAGE_FILE=${1:?"Usage: $0 <image_file>"}
+# IMAGE_FILE=$1
+# IMAGE_FILE=${$1:-"SWEB.qcow2"}
+
+SIZE_PRE=$(qemu-img info ${IMAGE_FILE} | sed -n -e 's|virtual size: .* (\(.*\) bytes)|\1|p')
+SIZE_POST=$(echo "x=l(${SIZE_PRE})/l(2); scale=0; 2^((x+0.5)/1)" | bc -l)
+
+echo "Resizing $IMAGE_FILE from $SIZE_PRE to $SIZE_POST bytes"
+
+qemu-img resize "${IMAGE_FILE}" "${SIZE_POST}"


### PR DESCRIPTION
- Resize disk image to next power of two (required when used as an sd card in newer qemu versions)
https://www.mail-archive.com/qemu-devel@nongnu.org/msg723028.html
This does not actually increase the size of the disk image file since we are using the qcow2 file format.

- Add a debug check in the arm verdex build scripts to check if the kernel image fits inside the available flash space on the board
(This currently fails and I suspect it has been failing for a long time now. ARM verdex support for SWEB is not in a great shape.)