### PR TITLE
change legacy qemu kvm64 cpu to host

### DIFF
--- a/arch/x86/64/CMakeLists.include
+++ b/arch/x86/64/CMakeLists.include
@@ -52,8 +52,8 @@ string(REPLACE ";" " " QEMU_FLAGS_COMMON_STR "${QEMU_FLAGS_COMMON}")
 
 # kvm: Run kvm in non debugging mode
 add_custom_target(kvm
-        COMMAND ${QEMU_BIN} ${QEMU_FLAGS_COMMON} -cpu kvm64
-        COMMENT "Executing `${QEMU_BIN} ${QEMU_FLAGS_COMMON_STR} -cpu kvm64`"
+        COMMAND ${QEMU_BIN} ${QEMU_FLAGS_COMMON} -enable-kvm -cpu host
+        COMMENT "Executing `${QEMU_BIN} ${QEMU_FLAGS_COMMON_STR} -enable-kvm -cpu host`"
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         COMMAND reset -I
         )


### PR DESCRIPTION
Change kvm target to use host cpu instead of the legacy kvm64 cpu.
This change should also make nested virtualization possible using the kvm target.