### PR TITLE
x86_64 fix boot time caching issue

### DIFF
--- a/arch/x86/64/source/init_boottime_pagetables.cpp
+++ b/arch/x86/64/source/init_boottime_pagetables.cpp
@@ -104,7 +104,7 @@ extern "C" void initialisePaging()
 
 extern "C" void removeBootTimeIdentMapping()
 {
-  uint64* pml4 = (uint64*)VIRTUAL_TO_PHYSICAL_BOOT(kernel_page_map_level_4);
+  uint64* pml4 = (uint64*)&kernel_page_map_level_4[0];
   pml4[0] = 0;
   pml4[1] = 0;
 }


### PR DESCRIPTION
Using the identity mapping to remove the identity mapping is probably not a good idea.
Probably only worked because it is very unlikely that the TLB gets flushed between line 108 and 109