### PR TITLE
[ArchThreads::atomic_add]: Fix for missing precision

### DIFF
--- a/arch/x86/64/source/ArchThreads.cpp
+++ b/arch/x86/64/source/ArchThreads.cpp
@@ -97,7 +97,7 @@ size_t ArchThreads::testSetLock(size_t &lock, size_t new_value)
 
 uint64 ArchThreads::atomic_add(uint64 &value, int64 increment)
 {
-  int32 ret=increment;
+  int64 ret=increment;
   __asm__ __volatile__(
   "lock; xadd %0, %1;"
   :"=a" (ret), "=m" (value)


### PR DESCRIPTION
Changed int32 to int64