### PR TITLE
Refactor + clean up file system code

### DIFF
--- a/common/include/console/debug.h
+++ b/common/include/console/debug.h
@@ -29,11 +29,6 @@ enum AnsiColor
 #define debug(flag, ...) do { if (flag & OUTPUT_ENABLED) { kprintfd(DEBUG_FORMAT_STRING, COLOR_PARAM(flag)); kprintfd(__VA_ARGS__); } } while (0)
 #endif
 
-//group minix
-const size_t M_STORAGE_MANAGER  = Ansi_Yellow;
-const size_t M_INODE            = Ansi_Yellow;
-const size_t M_SB               = Ansi_Yellow;
-const size_t M_ZONE             = Ansi_Yellow;
 
 //group Block Device
 const size_t BD_MANAGER         = Ansi_Yellow;
@@ -83,4 +78,8 @@ const size_t PSEUDOFS           = Ansi_Yellow;
 const size_t VFSSYSCALL         = Ansi_Yellow;
 const size_t VFS                = Ansi_Yellow | OUTPUT_ENABLED;
 
-
+//group minix
+const size_t M_STORAGE_MANAGER  = Ansi_Yellow;
+const size_t M_INODE            = Ansi_Yellow;
+const size_t M_SB               = Ansi_Yellow;
+const size_t M_ZONE             = Ansi_Yellow;

--- a/common/include/console/debug.h
+++ b/common/include/console/debug.h
@@ -73,10 +73,13 @@ const size_t A_INTERRUPTS       = Ansi_Yellow;
 const size_t FS                 = Ansi_Yellow;
 const size_t RAMFS              = Ansi_White;
 const size_t DENTRY             = Ansi_Blue;
+const size_t INODE              = Ansi_Blue;
 const size_t PATHWALKER         = Ansi_Yellow;
 const size_t PSEUDOFS           = Ansi_Yellow;
 const size_t VFSSYSCALL         = Ansi_Yellow;
 const size_t VFS                = Ansi_Yellow | OUTPUT_ENABLED;
+const size_t VFS_FILE           = Ansi_Yellow;
+const size_t SUPERBLOCK         = Ansi_Yellow;
 
 //group minix
 const size_t M_STORAGE_MANAGER  = Ansi_Yellow;

--- a/common/include/console/kprintf.h
+++ b/common/include/console/kprintf.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifndef EXE2MINIXFS
+
 #include "stdarg.h"
 #include "types.h"
 #include "debug.h"
@@ -27,3 +29,4 @@ void kprintfd(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
  */
 void kprintf_init();
 
+#endif

--- a/common/include/fs/Dentry.h
+++ b/common/include/fs/Dentry.h
@@ -90,7 +90,7 @@ class Dentry
      * return the mount_point of the current file-system
      * @return the dentry of the mount point
      */
-    Dentry* getMountPoint()
+    Dentry* getMountedRoot()
     {
       return d_mounts_;
     }
@@ -99,7 +99,7 @@ class Dentry
      * set the mount point
      * @param mount_point the dentry to set the mount point to
      */
-    void setMountPoint(Dentry *mount_point)
+    void setMountedRoot(Dentry *mount_point)
     {
       d_mounts_ = mount_point;
     }

--- a/common/include/fs/Dentry.h
+++ b/common/include/fs/Dentry.h
@@ -157,8 +157,8 @@ class Dentry
     virtual void childInsert(Dentry *child_dentry);
 
   public:
-    Dentry(const char* name);
-    Dentry(Dentry *parent);
+    Dentry(Inode* inode); // root dentry
+    Dentry(Inode* inode, Dentry* parent, const ustl::string& name); // named dentry
     virtual ~Dentry();
     ustl::string d_name_;
 };

--- a/common/include/fs/File.h
+++ b/common/include/fs/File.h
@@ -50,7 +50,7 @@ class File
     Superblock* f_superblock_;
 
     /**
-     * The indoe associated to the file.
+     * The inode associated to the file.
      */
     Inode* f_inode_;
 

--- a/common/include/fs/File.h
+++ b/common/include/fs/File.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "types.h"
+#include "ulist.h"
 
 class Superblock;
 class Inode;
 class Dentry;
+class FileDescriptor;
 
 #define O_RDONLY    0x0001
 #define O_WRONLY    0x0002
@@ -28,14 +30,10 @@ class Dentry;
 #define SEEK_END 2
 #endif
 
+
 class File
 {
   public:
-
-    class Owner
-    {
-    };
-
     uint32 uid;
     uint32 gid;
 
@@ -73,9 +71,9 @@ class File
     l_off_t offset_;
 
     /**
-     * indicates the owner of the file;
+     * List of open file descriptors
      */
-    Owner owner;
+    ustl::list<FileDescriptor*> f_fds_;
 
   public:
     /**
@@ -97,11 +95,14 @@ class File
      */
     File(Inode* inode, Dentry* dentry, uint32 flag);
 
-    virtual ~File()
-    {
-    }
+    virtual ~File();
 
-    Dentry *getDentry()
+    virtual FileDescriptor* openFd();
+    virtual int closeFd(FileDescriptor* fd);
+
+
+
+    Dentry* getDentry()
     {
       return f_dentry_;
     }
@@ -175,5 +176,3 @@ class File
 
     virtual uint32 getSize();
 };
-
-

--- a/common/include/fs/FileDescriptor.h
+++ b/common/include/fs/FileDescriptor.h
@@ -2,11 +2,12 @@
 
 #include "types.h"
 #include "ulist.h"
+#include "umap.h"
+#include "Mutex.h"
 
 class File;
 class FileDescriptor;
-
-extern ustl::list<FileDescriptor*> global_fd;
+class FileDescriptorList;
 
 class FileDescriptor
 {
@@ -16,11 +17,26 @@ class FileDescriptor
 
   public:
     FileDescriptor ( File* file );
-    virtual ~FileDescriptor() {}
+    virtual ~FileDescriptor();
     uint32 getFd() { return fd_; }
     File* getFile() { return file_; }
 
-    static void add(FileDescriptor* fd);
-    static void remove(FileDescriptor* fd);
+    friend File;
 };
 
+class FileDescriptorList
+{
+public:
+    FileDescriptorList();
+    ~FileDescriptorList();
+
+    int add(FileDescriptor* fd);
+    int remove(FileDescriptor* fd);
+    FileDescriptor* getFileDescriptor(uint32 fd);
+
+private:
+    ustl::list<FileDescriptor*> fds_;
+    Mutex fd_lock_;
+};
+
+extern FileDescriptorList global_fd_list;

--- a/common/include/fs/FileSystemInfo.h
+++ b/common/include/fs/FileSystemInfo.h
@@ -30,7 +30,7 @@ class FileSystemInfo
      * set the ROOT-info to the class
      * @param root the root path to set
      */
-    void setFsRoot(const Path& path)
+    void setRoot(const Path& path)
     {
       root_ = path;
     }
@@ -39,7 +39,7 @@ class FileSystemInfo
      * set the PWD-info to the class (PWD: print working directory)
      * @param path the current path to set
      */
-    void setFsPwd(const Path& path)
+    void setPwd(const Path& path)
     {
       pwd_ = path;
     }
@@ -61,8 +61,6 @@ class FileSystemInfo
     {
       return root_;
     }
-
-    ustl::string pathname_;
 };
 
 extern FileSystemInfo* default_working_dir;

--- a/common/include/fs/FileSystemInfo.h
+++ b/common/include/fs/FileSystemInfo.h
@@ -2,6 +2,7 @@
 
 #include "types.h"
 #include "ustring.h"
+#include "Path.h"
 
 class Dentry;
 class VfsMount;
@@ -10,34 +11,15 @@ class FileSystemInfo
 {
   protected:
     /**
-     * the root-directory
+     * File system root
      */
-    Dentry* root_;
+    Path root_;
 
     /**
-     * the root vfsmount-struct
+     * Current working directory
      */
-    VfsMount* root_mnt_;
+    Path pwd_;
 
-    /**
-     * the current-position-directory
-     */
-    Dentry* pwd_;
-
-    /**
-     * the current-position vfsmount-struct
-     */
-    VfsMount* pwd_mnt_;
-
-    /**
-     * the alternative-root-directory
-     */
-    Dentry* alt_root_;
-
-    /**
-     * the alternative-root vfsmount-struct
-     */
-    VfsMount* alt_root_mnt_;
 
   public:
     FileSystemInfo();
@@ -46,60 +28,38 @@ class FileSystemInfo
 
     /**
      * set the ROOT-info to the class
-     * @param root the root dentry to set
-     * @param root_mnt the root_mnt to set
+     * @param root the root path to set
      */
-    void setFsRoot(Dentry* root, VfsMount* root_mnt)
+    void setFsRoot(const Path& path)
     {
-      root_ = root;
-      root_mnt_ = root_mnt;
+      root_ = path;
     }
 
     /**
      * set the PWD-info to the class (PWD: print working directory)
-     * @param pwd the current path to set
-     * @param pwd_mnt the mount point of the current path to set
+     * @param path the current path to set
      */
-    void setFsPwd(Dentry* pwd, VfsMount* pwd_mnt)
+    void setFsPwd(const Path& path)
     {
-      pwd_ = pwd;
-      pwd_mnt_ = pwd_mnt;
+      pwd_ = path;
     }
 
     /**
      * get the ROOT-info (ROOT-directory) from the class
-     * @return the root dentry
+     * @return the root path
      */
-    Dentry* getRoot()
+    Path& getRoot()
     {
       return root_;
     }
 
     /**
-     * get the ROOT-info (ROOT-VfsMount-info) from the class
-     * @return the VfsMount
-     */
-    VfsMount* getRootMnt()
-    {
-      return root_mnt_;
-    }
-
-    /**
      * get the PWD-info (PWD-directory) from the class
-     * @return the dentry of the current directory
+     * @return the path of the current directory
      */
-    Dentry* getPwd()
+    Path& getPwd()
     {
-      return pwd_;
-    }
-
-    /**
-     * get the PWD-info (PWD-VfsMount-info) from the class
-     * @return the VfsMount of the current directory
-     */
-    VfsMount* getPwdMnt()
-    {
-      return pwd_mnt_;
+      return root_;
     }
 
     ustl::string pathname_;

--- a/common/include/fs/FileSystemType.h
+++ b/common/include/fs/FileSystemType.h
@@ -48,7 +48,7 @@ class FileSystemType
      * @return a pointer to the Superblock object, 0 if wasn't possible to
      * create a Superblock with the given device number
      */
-    virtual Superblock *createSuper(uint32 s_dev) const = 0;
+    virtual Superblock *createSuper(uint32 s_dev) = 0;
 
 };
 

--- a/common/include/fs/FileSystemType.h
+++ b/common/include/fs/FileSystemType.h
@@ -39,7 +39,7 @@ class FileSystemType
      * @param data is the data given to the mount system call.
      * @return is a pointer to the resulting superblock.
      */
-    virtual Superblock *readSuper(Superblock *superblock, void *data) const;
+    virtual Superblock *readSuper(Superblock *superblock, void *data) const = 0;
 
     /**
      * Creates an Superblock object for the actual file system type.
@@ -48,7 +48,7 @@ class FileSystemType
      * @return a pointer to the Superblock object, 0 if wasn't possible to
      * create a Superblock with the given device number
      */
-    virtual Superblock *createSuper(Dentry *root, uint32 s_dev) const;
+    virtual Superblock *createSuper(uint32 s_dev) const = 0;
 
 };
 

--- a/common/include/fs/Inode.h
+++ b/common/include/fs/Inode.h
@@ -91,6 +91,8 @@ class Inode
     {
     }
 
+    void incLinkCount() { i_nlink_++; }
+
     /**
      * Create a directory with the given dentry.
      * @param dentry the dentry
@@ -327,7 +329,6 @@ class Inode
     {
       return 0;
     }
-    ;
 
 };
 

--- a/common/include/fs/Inode.h
+++ b/common/include/fs/Inode.h
@@ -3,8 +3,10 @@
 #include "types.h"
 #include "kprintf.h"
 #include <ulist.h>
+#include <uatomic.h>
+#include "Dentry.h"
+#include "assert.h"
 
-class Dentry;
 class File;
 class Superblock;
 
@@ -39,8 +41,7 @@ class Superblock;
 class Inode
 {
   protected:
-    Dentry *i_dentry_;
-    ustl::list<Dentry*> i_dentry_link_;
+    ustl::list<Dentry*> i_dentrys_;
 
     /**
      * The (open) file of this inode.
@@ -48,9 +49,14 @@ class Inode
     ustl::list<File*> i_files_;
 
     /**
-     * the number of the link of this inode.
+     * the number of Dentry links to this inode.
      */
-    uint32 i_nlink_;
+    ustl::atomic<uint32> i_nlink_;
+
+    /**
+     * the number of runtime references to this inode (loaded Dentrys, open files, ...)
+     */
+    ustl::atomic<uint32> i_refcount_;
 
     Superblock *superblock_;
 
@@ -60,7 +66,7 @@ class Inode
     uint32 i_size_;
 
     /**
-     * There are three possible inode type bits: I_FILE, I_DIR, I_LNK
+     * Inode type: I_FILE, I_DIR, I_LNK, ...
      */
     uint32 i_type_;
 
@@ -80,28 +86,21 @@ class Inode
      * @param super_block the superblock to create the inode on
      * @param inode_type the inode type
      */
-    Inode(Superblock *super_block, uint32 inode_type) :
-        i_dentry_(0), i_nlink_(0), i_size_(0), i_state_(I_UNUSED)
-    {
-      superblock_ = super_block, i_type_ = inode_type;
-      i_mode_ = (A_READABLE ^ A_WRITABLE) ^ A_EXECABLE;
-    }
+    Inode(Superblock *super_block, uint32 inode_type);
 
-    virtual ~Inode()
-    {
-    }
+    virtual ~Inode();
 
-    void incLinkCount() { i_nlink_++; }
+    uint32 incRefCount();
+    uint32 decRefCount();
+    uint32 numRefs();
 
-    /**
-     * Create a directory with the given dentry.
-     * @param dentry the dentry
-     * @return 0 on success
-     */
-    virtual int32 create(Dentry *)
-    {
-      return 0;
-    }
+    uint32 incLinkCount();
+    uint32 decLinkCount();
+
+    void addDentry(Dentry* dentry);
+    void removeDentry(Dentry* dentry);
+    bool hasDentry(Dentry* dentry);
+
 
     /**
      * lookup should check if that name (given by the char-array) exists in the
@@ -111,15 +110,12 @@ class Inode
      * @param name the name to look for
      * @return the dentry found
      */
-    virtual Dentry* lookup(const char* /*name*/)
-    {
-      return 0;
-    }
+    virtual Dentry* lookup(const char* /*name*/);
 
     /**
      * Called when a file is opened
      */
-    virtual File* open(uint32 /*flag*/)
+    virtual File* open(Dentry* /*dentry*/, uint32 /*flag*/)
     {
       return 0;
     }
@@ -127,33 +123,7 @@ class Inode
     /**
      * Called when the last reference to a file is closed
      */
-    virtual int32 release(File* /*file*/)
-    {
-      return 0;
-    }
-
-    /**
-     * The link method should make a hard link to the name referred to by the
-     * denty, which is in the directory refered to by the Inode.
-     * (only used for File)
-     * @param flag the flag
-     * @return the link file
-     */
-    // virtual File* link(uint32 /*flag*/)
-    // {
-    //   return 0;
-    // }
-
-    /**
-     * This should remove the name refered to by the Dentry from the directory
-     * referred to by the inode. (only used for File)
-     * @param file the file to unlink
-     * @retunr 0 on success
-     */
-    // virtual int32 unlink(File* /*file*/)
-    // {
-    //   return -1;
-    // }
+    virtual int32 release(File* /*file*/);
 
     /**
      * This should create a symbolic link in the given directory with the given
@@ -174,48 +144,41 @@ class Inode
      * @param the dentry
      * @return 0 on success
      */
-    virtual int32 mkdir(Dentry *)
-    {
-      return 0;
-    }
+    virtual int32 mkdir(Dentry *);
 
     /**
      * Create a file with the given dentry.
      * @param dentry the dentry
      * @return 0 on success
      */
-    virtual int32 mkfile(Dentry */*dentry*/)
-    {
-      return 0;
-    }
+    virtual int32 mkfile(Dentry */*dentry*/);
 
     /**
      * Create a special file with the given dentry.
      * @param the dentry
      * @return 0 on success
      */
-    virtual int32 mknod(Dentry *)
-    {
-      return 0;
-    }
+    virtual int32 mknod(Dentry*);
+
+    /**
+     * Create a hard link with the given dentry.
+     * @param the dentry
+     * @return 0 on success
+     */
+    virtual int32 link(Dentry*);
+
+    /**
+     * Unlink the given dentry from the inode.
+     * @param the dentry
+     * @return 0 on success
+     */
+    virtual int32 unlink(Dentry*);
 
     /**
      * Remove the named directory (if empty).
      * @return 0 on success
      */
-    virtual int32 rmdir()
-    {
-      return 0;
-    }
-
-    /**
-     * Remove the named directory (if empty) or file
-     * @return 0 on success
-     */
-    virtual int32 rm()
-    {
-      return 0;
-    }
+    virtual int32 rmdir(Dentry*);
 
     /**
      * change the name to new_name
@@ -277,35 +240,11 @@ class Inode
       return 0;
     }
 
-    /**
-     * insert the opened file point to the file_list of this inode.
-     * @param file the file to insert
-     * @return 0 on success
-     */
-    int32 insertOpenedFiles(File*);
-
-    /**
-     * remove the opened file point from the file_list of this inode.
-     * @param file the file to remove
-     * @return 0 on success
-     */
-    int32 removeOpenedFiles(File*);
-
-    bool openedFilesEmpty()
-    {
-      return (i_files_.empty());
-    }
-
     Superblock* getSuperblock()
     {
       return superblock_;
     }
 
-    /**
-     * setting the superblock is neccessary because the devices
-     * are created before the DeviceFS is created
-     * @param sb the superblock to set
-     */
     void setSuperBlock(Superblock * sb)
     {
       superblock_ = sb;
@@ -316,14 +255,9 @@ class Inode
       return i_type_;
     }
 
-    Dentry* getDentry()
+    ustl::list<Dentry*>& getDentrys()
     {
-      return i_dentry_;
-    }
-
-    File* getFirstFile()
-    {
-      return i_files_.front();
+      return i_dentrys_;
     }
 
     uint32 getNumOpenedFile()
@@ -345,6 +279,4 @@ class Inode
     {
       return 0;
     }
-
 };
-

--- a/common/include/fs/Inode.h
+++ b/common/include/fs/Inode.h
@@ -117,16 +117,32 @@ class Inode
     }
 
     /**
+     * Called when a file is opened
+     */
+    virtual File* open(uint32 /*flag*/)
+    {
+      return 0;
+    }
+
+    /**
+     * Called when the last reference to a file is closed
+     */
+    virtual int32 release(File* /*file*/)
+    {
+      return 0;
+    }
+
+    /**
      * The link method should make a hard link to the name referred to by the
      * denty, which is in the directory refered to by the Inode.
      * (only used for File)
      * @param flag the flag
      * @return the link file
      */
-    virtual File* link(uint32 /*flag*/)
-    {
-      return 0;
-    }
+    // virtual File* link(uint32 /*flag*/)
+    // {
+    //   return 0;
+    // }
 
     /**
      * This should remove the name refered to by the Dentry from the directory
@@ -134,10 +150,10 @@ class Inode
      * @param file the file to unlink
      * @retunr 0 on success
      */
-    virtual int32 unlink(File* /*file*/)
-    {
-      return 0;
-    }
+    // virtual int32 unlink(File* /*file*/)
+    // {
+    //   return -1;
+    // }
 
     /**
      * This should create a symbolic link in the given directory with the given
@@ -174,6 +190,16 @@ class Inode
     }
 
     /**
+     * Create a special file with the given dentry.
+     * @param the dentry
+     * @return 0 on success
+     */
+    virtual int32 mknod(Dentry *)
+    {
+      return 0;
+    }
+
+    /**
      * Remove the named directory (if empty).
      * @return 0 on success
      */
@@ -187,16 +213,6 @@ class Inode
      * @return 0 on success
      */
     virtual int32 rm()
-    {
-      return 0;
-    }
-
-    /**
-     * Create a directory with the given dentry.
-     * @param the dentry
-     * @return 0 on success
-     */
-    virtual int32 mknod(Dentry *)
     {
       return 0;
     }

--- a/common/include/fs/Path.h
+++ b/common/include/fs/Path.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "types.h"
+#include "ustring.h"
+
 class Dentry;
 class VfsMount;
 
@@ -11,6 +14,12 @@ public:
     Path(const Path&) = default;
     Path& operator=(const Path&) = default;
     bool operator==(const Path&) const;
+
+    Path parentDir(const Path* global_root = nullptr) const;
+    ustl::string getAbsolutePath(const Path* global_root = nullptr) const;
+
+    bool isGlobalRoot(const Path* global_root = nullptr) const;
+    bool isMountRoot() const;
 
     Dentry* dentry_;
     VfsMount* mnt_;

--- a/common/include/fs/Path.h
+++ b/common/include/fs/Path.h
@@ -1,0 +1,17 @@
+#pragma once
+
+class Dentry;
+class VfsMount;
+
+class Path
+{
+public:
+    Path() = default;
+    Path(Dentry* dentry, VfsMount* mnt);
+    Path(const Path&) = default;
+    Path& operator=(const Path&) = default;
+    bool operator==(const Path&) const;
+
+    Dentry* dentry_;
+    VfsMount* mnt_;
+};

--- a/common/include/fs/Path.h
+++ b/common/include/fs/Path.h
@@ -15,7 +15,9 @@ public:
     Path& operator=(const Path&) = default;
     bool operator==(const Path&) const;
 
-    Path parentDir(const Path* global_root = nullptr) const;
+    Path parent(const Path* global_root = nullptr) const;
+    int child(const ustl::string& name, Path& out) const;
+
     ustl::string getAbsolutePath(const Path* global_root = nullptr) const;
 
     bool isGlobalRoot(const Path* global_root = nullptr) const;

--- a/common/include/fs/PathWalker.h
+++ b/common/include/fs/PathWalker.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "types.h"
+#include "ustring.h"
 
 class Dentry;
 class VfsMount;
 class Path;
+class FileSystemInfo;
 
 #define MAX_NAME_LEN 100
 
@@ -94,6 +96,11 @@ class PathWalker
      * @return Returns 0 on success, != 0 on error
      */
     static int32 pathWalk(const char* pathname, const Path& pwd, const Path& root, uint32 flags_ __attribute__ ((unused)), Path& out, Path* parent = nullptr);
+
+    static int32 pathWalk(const char* pathname, FileSystemInfo* fs_info, uint32 flags_ __attribute__ ((unused)), Path& out, Path* parent_dir = nullptr);
+
+    static ustl::string pathPrefix(const ustl::string& path);
+    static ustl::string lastPathSegment(const ustl::string& path, bool ignore_separator_at_end = false);
 
   protected:
 

--- a/common/include/fs/PathWalker.h
+++ b/common/include/fs/PathWalker.h
@@ -4,6 +4,7 @@
 
 class Dentry;
 class VfsMount;
+class Path;
 
 #define MAX_NAME_LEN 100
 
@@ -85,12 +86,14 @@ class PathWalker
      * to the dentry_ object and mounted filesystem object relative to the last
      * component of the pathname.
      * @param pathname A pointer to the file pathname to be resolved
-     * @param flags The vlaue of flags that represent how to look-up file is going
+     * @param start Start directory of the file system walk
+     * @param root Root directory for the file system walk
+     * @param flags The value of flags that represent how to look-up file is going
      *         to be accessed
-     * @return On success, it is returned 0. On error, it return a non-Null value.
+     * @param out Output parameter: Found file path
+     * @return Returns 0 on success, != 0 on error
      */
-    static int32 pathWalk(const char* pathname, uint32 flags_ __attribute__ ((unused)), Dentry*& dentry_,
-                          VfsMount*& vfs_mount_);
+    static int32 pathWalk(const char* pathname, const Path& pwd, const Path& root, uint32 flags_ __attribute__ ((unused)), Path& out);
 
   protected:
 

--- a/common/include/fs/PathWalker.h
+++ b/common/include/fs/PathWalker.h
@@ -93,7 +93,7 @@ class PathWalker
      * @param out Output parameter: Found file path
      * @return Returns 0 on success, != 0 on error
      */
-    static int32 pathWalk(const char* pathname, const Path& pwd, const Path& root, uint32 flags_ __attribute__ ((unused)), Path& out);
+    static int32 pathWalk(const char* pathname, const Path& pwd, const Path& root, uint32 flags_ __attribute__ ((unused)), Path& out, Path* parent = nullptr);
 
   protected:
 

--- a/common/include/fs/PathWalker.h
+++ b/common/include/fs/PathWalker.h
@@ -8,28 +8,6 @@ class VfsMount;
 class Path;
 class FileSystemInfo;
 
-#define MAX_NAME_LEN 100
-
-/**
- * If the last component is a symbolic link follow it
- */
-#define LOOKUP_FOLLOW     0x0001
-
-/**
- * If this flag is set the last component must be a directory
- */
-#define LOOKUP_DIRECTORY  0x0002
-
-/**
- * If this flag is set the last component of the pathname must exist
- */
-#define LOOKUP_POSITICE   0x0004
-
-/**
- * If this flag is set lookup the directory including the last component
- */
-#define LOOKUP_PARENT     0x0008
-
 /**
  * @enum Type of the last component on LOOKUP_PARENT
  */
@@ -41,11 +19,6 @@ enum
   LAST_NORM,
 
   /**
-   * The last component is the root directory
-   */
-  LAST_ROOT,
-
-  /**
    * The last component is "."
    */
   LAST_DOT,
@@ -54,11 +27,6 @@ enum
    * The last component is ".."
    */
   LAST_DOTDOT,
-
-  /**
-   * The last component is a symbolic link into a special filesystem
-   */
-  LAST_BIND
 };
 
 /**
@@ -82,36 +50,25 @@ class PathWalker
   public:
 
     /**
-     * check the first character of the path (begins with '/' or
-     * with pwd). Initialize the flags_.
-     * takes care of the lookup operation and stores the pointers
-     * to the dentry_ object and mounted filesystem object relative to the last
-     * component of the pathname.
-     * @param pathname A pointer to the file pathname to be resolved
-     * @param start Start directory of the file system walk
+     * Perform a file system lookup
+     * @param pathname File pathname to be resolved
+     * @param pwd Start directory of the file system walk
      * @param root Root directory for the file system walk
-     * @param flags The value of flags that represent how to look-up file is going
-     *         to be accessed
      * @param out Output parameter: Found file path
+     * @param parent Optional output parameter: Parent directory
      * @return Returns 0 on success, != 0 on error
      */
-    static int32 pathWalk(const char* pathname, const Path& pwd, const Path& root, uint32 flags_ __attribute__ ((unused)), Path& out, Path* parent = nullptr);
+    static int32 pathWalk(const char* pathname, const Path& pwd, const Path& root, Path& out, Path* parent = nullptr);
 
-    static int32 pathWalk(const char* pathname, FileSystemInfo* fs_info, uint32 flags_ __attribute__ ((unused)), Path& out, Path* parent_dir = nullptr);
+    static int32 pathWalk(const char* pathname, FileSystemInfo* fs_info, Path& out, Path* parent_dir = nullptr);
 
     static ustl::string pathPrefix(const ustl::string& path);
     static ustl::string lastPathSegment(const ustl::string& path, bool ignore_separator_at_end = false);
 
-  protected:
-
-    /**
-     * extract the first part of a path
-     * @param path is a char* containing the path to get the next part from.
-     * @param npart_len will be set to the length of the next part
-     * @return length of the next part
-     */
-    static int32 getNextPartLen(const char* path, int32& npart_len);
   private:
+    static size_t getNextPartLen(const char* path);
+    static int pathSegmentType(const char* segment);
+
     PathWalker();
     ~PathWalker();
 };

--- a/common/include/fs/Superblock.h
+++ b/common/include/fs/Superblock.h
@@ -127,7 +127,7 @@ class Superblock
      * used.
      * @param inode the inode to delete
      */
-    virtual void delete_inode(Inode* /*inode*/);
+    virtual void deleteInode(Inode* /*inode*/);
 
     /**
      * create a file with the given flag and  a file descriptor with the given

--- a/common/include/fs/Superblock.h
+++ b/common/include/fs/Superblock.h
@@ -55,7 +55,7 @@ class Superblock
     /**
      * The old Dentry of the mount point of a mounted file system
      */
-    Dentry *mounted_over_;
+    Dentry *s_mountpoint_;
 
     /**
      * A list of dirty inodes.
@@ -83,10 +83,9 @@ class Superblock
 
     /**
      * constructor
-     * @param s_root the root dentry of the new filesystme
      * @param s_dev the device number of the new filesystem
      */
-    Superblock(Dentry* s_root, size_t s_dev);
+    Superblock(size_t s_dev);
 
     virtual ~Superblock();
 
@@ -162,6 +161,11 @@ class Superblock
      * @return the superblocks mount point dentry
      */
     Dentry *getMountPoint();
+
+    /**
+     * Set the mount point Dentry of the Superblock
+     */
+    void setMountPoint(Dentry* mountpoint);
 
     /**
      * Get the File System Type of the Superblock

--- a/common/include/fs/Superblock.h
+++ b/common/include/fs/Superblock.h
@@ -85,7 +85,7 @@ class Superblock
      * constructor
      * @param s_dev the device number of the new filesystem
      */
-    Superblock(size_t s_dev);
+    Superblock(FileSystemType* fs_type, size_t s_dev);
 
     virtual ~Superblock();
 

--- a/common/include/fs/Superblock.h
+++ b/common/include/fs/Superblock.h
@@ -91,12 +91,12 @@ class Superblock
     virtual ~Superblock();
 
     /**
-     * create a new Inode of the superblock, mknod with dentry, add in the list.
+     * create a new Inode of the superblock
      * @param dentry the dentry to create the inode with
      * @param type the inode type
      * @return the created inode
      */
-    virtual Inode* createInode(Dentry* /*dentry*/, uint32 /*type*/) = 0;
+    virtual Inode* createInode(uint32 type) = 0;
 
     /**
      * This method is called to read a specific inode from a mounted

--- a/common/include/fs/Superblock.h
+++ b/common/include/fs/Superblock.h
@@ -77,7 +77,8 @@ class Superblock
      * file-system. It is used, for example, to check if there are any files
      * open for write before remounting the file-system as read-only.
      */
-    ustl::list<FileDescriptor*> s_files_;
+    ustl::list<File*> s_files_;
+
 
   public:
 
@@ -107,7 +108,6 @@ class Superblock
     {
       return 0;
     }
-    ;
 
     /**
      * This method is called to write a specific inode to a mounted file-system,
@@ -117,7 +117,6 @@ class Superblock
     virtual void writeInode(Inode* /*inode*/)
     {
     }
-    ;
 
     /**
      * This method is called whenever the reference count on an inode reaches 0,
@@ -129,26 +128,12 @@ class Superblock
      */
     virtual void deleteInode(Inode* /*inode*/);
 
-    /**
-     * create a file with the given flag and  a file descriptor with the given
-     * inode.
-     * @param inode the inode to create the fd for
-     * @param flag the flag
-     * @return the fd
-     */
-    virtual int32 createFd(Inode* /*inode*/, uint32 /*flag*/) = 0;
 
-    /**
-     * remove the corresponding file descriptor.
-     * @param inode the indo from which to remove the fd
-     * @param file the fd to remove
-     * @return 0 on success
-     */
-    virtual int32 removeFd(Inode* /*inode*/, FileDescriptor* /*file*/)
-    {
-      return 0;
-    }
-    ;
+    virtual int fileOpened(File* file);
+    virtual int fileReleased(File* file);
+
+    virtual void releaseAllOpenFiles();
+    virtual void deleteAllInodes();
 
     /**
      * Get the root Dentry of the Superblock

--- a/common/include/fs/VfsMount.h
+++ b/common/include/fs/VfsMount.h
@@ -99,6 +99,9 @@ class VfsMount
    */
   void clear();
 
+
+  bool isRootMount() const;
+
 };
 
 

--- a/common/include/fs/VfsSyscall.h
+++ b/common/include/fs/VfsSyscall.h
@@ -18,7 +18,7 @@ class VfsSyscall
      * @param pathname the input pathname
      * @return On success, zero is returned. On error, -1 is returned.
      */
-    static int32 dupChecking(const char* pathname, const Path& pwd, const Path& root, Path& out_path);
+    static int32 dupChecking(const char* pathname, const Path& pwd, const Path& root, Path& out_path, Path* parent_dir = nullptr);
 
   public:
 

--- a/common/include/fs/VfsSyscall.h
+++ b/common/include/fs/VfsSyscall.h
@@ -12,17 +12,6 @@ class FileSystemInfo;
 
 class VfsSyscall
 {
-  protected:
-
-    /**
-     * checks the duplication from the pathname in the file-system
-     * @param pathname the input pathname
-     * @return On success, zero is returned. On error, -1 is returned.
-     */
-    static int32 dupChecking(const char* pathname, const Path& pwd, const Path& root, Path& out_path, Path* parent_dir = nullptr);
-
-    static int32 dupChecking(const char* pathname, FileSystemInfo* fs_info, Path& out_path, Path* parent_dir = nullptr);
-
   public:
 
     /**

--- a/common/include/fs/VfsSyscall.h
+++ b/common/include/fs/VfsSyscall.h
@@ -7,6 +7,7 @@ class Dentry;
 class VfsMount;
 class FileDescriptor;
 class VfsSyscall;
+class Path;
 
 class VfsSyscall
 {
@@ -17,7 +18,7 @@ class VfsSyscall
      * @param pathname the input pathname
      * @return On success, zero is returned. On error, -1 is returned.
      */
-    static int32 dupChecking(const char* pathname, Dentry*& pw_dentry, VfsMount*& pw_vfs_mount);
+    static int32 dupChecking(const char* pathname, const Path& pwd, const Path& root, Path& out_path);
 
   public:
 

--- a/common/include/fs/VfsSyscall.h
+++ b/common/include/fs/VfsSyscall.h
@@ -8,6 +8,7 @@ class VfsMount;
 class FileDescriptor;
 class VfsSyscall;
 class Path;
+class FileSystemInfo;
 
 class VfsSyscall
 {
@@ -19,6 +20,8 @@ class VfsSyscall
      * @return On success, zero is returned. On error, -1 is returned.
      */
     static int32 dupChecking(const char* pathname, const Path& pwd, const Path& root, Path& out_path, Path* parent_dir = nullptr);
+
+    static int32 dupChecking(const char* pathname, FileSystemInfo* fs_info, Path& out_path, Path* parent_dir = nullptr);
 
   public:
 

--- a/common/include/fs/VirtualFileSystem.h
+++ b/common/include/fs/VirtualFileSystem.h
@@ -92,7 +92,7 @@ class VirtualFileSystem
      * @param flags the mount flags
      * @return On success, zero is returned. On error, -1 is returned.
      */
-    FileSystemInfo *root_mount(const char* fs_name, uint32 flags);
+    FileSystemInfo *rootMount(const char* fs_name, uint32 flags);
 
     /**
      * umount the ROOT from the VFS (special of the umount)

--- a/common/include/fs/devicefs/DeviceFSSuperblock.h
+++ b/common/include/fs/devicefs/DeviceFSSuperblock.h
@@ -1,27 +1,20 @@
 #pragma once
 
 #include "fs/Superblock.h"
+#include "fs/ramfs/RamFSSuperblock.h"
 
 class Inode;
 class Superblock;
 class CharacterDevice;
 class DeviceFSType;
 
-class DeviceFSSuperBlock : public Superblock
+class DeviceFSSuperBlock : public RamFSSuperblock
 {
   public:
     static const char ROOT_NAME[];
     static const char DEVICE_ROOT_NAME[];
 
     virtual ~DeviceFSSuperBlock();
-
-    /**
-     * creates a new Inode of the superblock
-     * @param dentry the dentry for the new indoe
-     * @param type the type of the new inode
-     * @return the inode
-     */
-    virtual Inode* createInode(uint32 type);
 
     /**
      * addsa new device to the superblock

--- a/common/include/fs/devicefs/DeviceFSSuperblock.h
+++ b/common/include/fs/devicefs/DeviceFSSuperblock.h
@@ -5,6 +5,7 @@
 class Inode;
 class Superblock;
 class CharacterDevice;
+class DeviceFSType;
 
 class DeviceFSSuperBlock : public Superblock
 {
@@ -48,12 +49,7 @@ class DeviceFSSuperBlock : public Superblock
     /**
      * Access method to the singleton instance
      */
-    static DeviceFSSuperBlock* getInstance()
-    {
-      if (!instance_)
-        instance_ = new DeviceFSSuperBlock(0);
-      return instance_;
-    }
+    static DeviceFSSuperBlock* getInstance();
 
   private:
 
@@ -62,7 +58,7 @@ class DeviceFSSuperBlock : public Superblock
      * @param s_root the root Dentry of the new Filesystem
      * @param s_dev the device number of the new Filesystem
      */
-    DeviceFSSuperBlock(uint32 s_dev);
+    DeviceFSSuperBlock(DeviceFSType* fs_type, uint32 s_dev);
 
   protected:
     static DeviceFSSuperBlock* instance_;

--- a/common/include/fs/devicefs/DeviceFSSuperblock.h
+++ b/common/include/fs/devicefs/DeviceFSSuperblock.h
@@ -51,7 +51,7 @@ class DeviceFSSuperBlock : public Superblock
     static DeviceFSSuperBlock* getInstance()
     {
       if (!instance_)
-        instance_ = new DeviceFSSuperBlock(0, 0);
+        instance_ = new DeviceFSSuperBlock(0);
       return instance_;
     }
 
@@ -62,7 +62,7 @@ class DeviceFSSuperBlock : public Superblock
      * @param s_root the root Dentry of the new Filesystem
      * @param s_dev the device number of the new Filesystem
      */
-    DeviceFSSuperBlock(Dentry* s_root, uint32 s_dev);
+    DeviceFSSuperBlock(uint32 s_dev);
 
   protected:
     static DeviceFSSuperBlock* instance_;

--- a/common/include/fs/devicefs/DeviceFSSuperblock.h
+++ b/common/include/fs/devicefs/DeviceFSSuperblock.h
@@ -20,7 +20,7 @@ class DeviceFSSuperBlock : public Superblock
      * @param type the type of the new inode
      * @return the inode
      */
-    virtual Inode* createInode(Dentry* dentry, uint32 type);
+    virtual Inode* createInode(uint32 type);
 
     /**
      * creates a file descriptor for the given inode

--- a/common/include/fs/devicefs/DeviceFSSuperblock.h
+++ b/common/include/fs/devicefs/DeviceFSSuperblock.h
@@ -24,22 +24,6 @@ class DeviceFSSuperBlock : public Superblock
     virtual Inode* createInode(uint32 type);
 
     /**
-     * creates a file descriptor for the given inode
-     * @param inode the inode to create the fd for
-     * @param flag the flag of the fd
-     * @return the file descriptor
-     */
-    virtual int32 createFd(Inode* inode, uint32 flag);
-
-    /**
-     * remove the corresponding file descriptor.
-     * @param inode the inode from which to remove the fd from
-     * @param fd the fd to remove
-     * @return 0 on success
-     */
-    virtual int32 removeFd(Inode* inode, FileDescriptor* fd);
-
-    /**
      * addsa new device to the superblock
      * @param inode the inode of the device to add
      * @param node_name the device name

--- a/common/include/fs/devicefs/DeviceFSSuperblock.h
+++ b/common/include/fs/devicefs/DeviceFSSuperblock.h
@@ -41,9 +41,9 @@ class DeviceFSSuperBlock : public Superblock
     /**
      * addsa new device to the superblock
      * @param inode the inode of the device to add
-     * @param device_name the device name
+     * @param node_name the device name
      */
-    void addDevice(Inode* inode, const char* device_name);
+    void addDevice(Inode* inode, const char* node_name);
 
     /**
      * Access method to the singleton instance
@@ -63,9 +63,6 @@ class DeviceFSSuperBlock : public Superblock
      * @param s_dev the device number of the new Filesystem
      */
     DeviceFSSuperBlock(Dentry* s_root, uint32 s_dev);
-
-    Inode* cDevice;
-    Dentry* s_dev_dentry_;
 
   protected:
     static DeviceFSSuperBlock* instance_;

--- a/common/include/fs/devicefs/DeviceFSType.h
+++ b/common/include/fs/devicefs/DeviceFSType.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "fs/FileSystemType.h"
+#include "fs/ramfs/RamFSType.h"
 
-class DeviceFSType : public FileSystemType
+class DeviceFSType : public RamFSType
 {
   public:
     DeviceFSType();

--- a/common/include/fs/devicefs/DeviceFSType.h
+++ b/common/include/fs/devicefs/DeviceFSType.h
@@ -23,6 +23,6 @@ class DeviceFSType : public FileSystemType
      * @param s_dev the device number of the new superblock
      * @return a pointer to the Superblock object
      */
-    virtual Superblock *createSuper(Dentry *root, uint32 s_dev) const;
+    virtual Superblock *createSuper(uint32 s_dev) const;
 };
 

--- a/common/include/fs/devicefs/DeviceFSType.h
+++ b/common/include/fs/devicefs/DeviceFSType.h
@@ -23,6 +23,11 @@ class DeviceFSType : public FileSystemType
      * @param s_dev the device number of the new superblock
      * @return a pointer to the Superblock object
      */
-    virtual Superblock *createSuper(uint32 s_dev) const;
+    virtual Superblock *createSuper(uint32 s_dev);
+
+    static DeviceFSType* getInstance();
+
+protected:
+    static DeviceFSType* instance_;
 };
 

--- a/common/include/fs/minixfs/MinixFSInode.h
+++ b/common/include/fs/minixfs/MinixFSInode.h
@@ -59,13 +59,22 @@ class MinixFSInode : public Inode
     virtual Dentry* lookup(const char *name);
 
     /**
+     * Called when a file is opened
+     */
+    virtual File* open(uint32 /*flag*/);
+    /**
+     * Called when the last reference to a file is closed
+     */
+    virtual int32 release(File* /*file*/);
+
+    /**
      * The link method makes a hard link to the name referred to by the
      * denty, which is in the directory refered to by the Inode.
      * (only used for File)
      * @param flag the flag
      * @return the created file
      */
-    virtual File* link(uint32 flag);
+    // virtual File* link(uint32 flag);
 
     /**
      * This removes the name refered to by the Dentry from the directory
@@ -73,7 +82,7 @@ class MinixFSInode : public Inode
      * @param file the file to unlink
      * @return 0 on success
      */
-    virtual int32 unlink(File* file);
+    // virtual int32 unlink(File* file);
 
     /**
      * creates a directory with the given dentry. It is only used to with directory.

--- a/common/include/fs/minixfs/MinixFSInode.h
+++ b/common/include/fs/minixfs/MinixFSInode.h
@@ -61,28 +61,7 @@ class MinixFSInode : public Inode
     /**
      * Called when a file is opened
      */
-    virtual File* open(uint32 /*flag*/);
-    /**
-     * Called when the last reference to a file is closed
-     */
-    virtual int32 release(File* /*file*/);
-
-    /**
-     * The link method makes a hard link to the name referred to by the
-     * denty, which is in the directory refered to by the Inode.
-     * (only used for File)
-     * @param flag the flag
-     * @return the created file
-     */
-    // virtual File* link(uint32 flag);
-
-    /**
-     * This removes the name refered to by the Dentry from the directory
-     * referred to by the inode. (only used for File)
-     * @param file the file to unlink
-     * @return 0 on success
-     */
-    // virtual int32 unlink(File* file);
+    virtual File* open(Dentry* dentry, uint32 /*flag*/);
 
     /**
      * creates a directory with the given dentry. It is only used to with directory.
@@ -91,17 +70,15 @@ class MinixFSInode : public Inode
      */
     virtual int32 mkdir(Dentry *dentry);
 
+    virtual int32 link(Dentry* dentry);
+    virtual int32 unlink(Dentry* dentry);
+
     /**
      * removes the directory (if it is empty)
      * @return 0 on success
      */
-    virtual int32 rmdir();
+    virtual int32 rmdir(Dentry* dentry);
 
-    /**
-     * removes the named directory (if empty) or file (if not opened)
-     * @return 0 on success
-     */
-    virtual int32 rm();
 
     /**
      * creates a directory with the given dentry.
@@ -161,8 +138,4 @@ class MinixFSInode : public Inode
      * true if the inodes children are allready loaded
      */
     bool children_loaded_;
-
-    ustl::list<Dentry*> other_dentries_;
-
 };
-

--- a/common/include/fs/minixfs/MinixFSSuperblock.h
+++ b/common/include/fs/minixfs/MinixFSSuperblock.h
@@ -7,6 +7,7 @@
 class Inode;
 class MinixFSInode;
 class Superblock;
+class MinixFSType;
 
 class MinixFSSuperblock : public Superblock
 {
@@ -15,7 +16,7 @@ class MinixFSSuperblock : public Superblock
     friend class MinixFSZone;
     friend class MinixStorageManager;
 
-    MinixFSSuperblock(size_t s_dev, uint64 offset);
+    MinixFSSuperblock(MinixFSType* fs_type, size_t s_dev, uint64 offset);
     virtual ~MinixFSSuperblock();
 
     /**
@@ -200,11 +201,6 @@ class MinixFSSuperblock : public Superblock
 
     MinixStorageManager* storage_manager_;
 
-    /**
-     * offset in the image file (in image util)
-     */
-    uint64 offset_;
-
 
     ustl::map<uint32, Inode*> all_inodes_set_;
 
@@ -212,5 +208,10 @@ class MinixFSSuperblock : public Superblock
      * pointer to self for compatability
      */
     Superblock* superblock_;
+
+    /**
+     * offset in the image file (in image util)
+     */
+    uint64 offset_;
 };
 

--- a/common/include/fs/minixfs/MinixFSSuperblock.h
+++ b/common/include/fs/minixfs/MinixFSSuperblock.h
@@ -27,14 +27,6 @@ class MinixFSSuperblock : public Superblock
     virtual Inode* createInode(uint32 type);
 
     /**
-     *  remove the corresponding file descriptor and unlinks it from the inode.
-     * @param inode the inode the file descriptor is linked to
-     * @param fd the file descriptor
-     * @return 0 on success
-     */
-    virtual int32 removeFd(Inode* inode, FileDescriptor* fd);
-
-    /**
      * reads one inode from the mounted file system
      * @param inode the inode to read
      * @return 0 on success
@@ -64,14 +56,6 @@ class MinixFSSuperblock : public Superblock
      * @param inode to remove
      */
     void all_inodes_remove_inode(Inode* inode);
-
-    /**
-     * create a file with the given flag and a file descriptor with the given inode.
-     * @param inode the inode to link the file with
-     * @param flag the flag to create the file with
-     * @return the file descriptor
-     */
-    virtual int32 createFd(Inode* inode, uint32 flag);
 
     /**
      * allocates one zone on the file system

--- a/common/include/fs/minixfs/MinixFSSuperblock.h
+++ b/common/include/fs/minixfs/MinixFSSuperblock.h
@@ -51,7 +51,7 @@ class MinixFSSuperblock : public Superblock
      * removes one inode from the file system and frees all its resources
      * @param inode the inode to delete
      */
-    virtual void delete_inode(Inode* inode);
+    virtual void deleteInode(Inode* inode);
 
     /**
      * add an inode to the all_inodes_ data structures

--- a/common/include/fs/minixfs/MinixFSSuperblock.h
+++ b/common/include/fs/minixfs/MinixFSSuperblock.h
@@ -15,7 +15,7 @@ class MinixFSSuperblock : public Superblock
     friend class MinixFSZone;
     friend class MinixStorageManager;
 
-    MinixFSSuperblock(Dentry* s_root, size_t s_dev, uint64 offset);
+    MinixFSSuperblock(size_t s_dev, uint64 offset);
     virtual ~MinixFSSuperblock();
 
     /**

--- a/common/include/fs/minixfs/MinixFSSuperblock.h
+++ b/common/include/fs/minixfs/MinixFSSuperblock.h
@@ -19,12 +19,11 @@ class MinixFSSuperblock : public Superblock
     virtual ~MinixFSSuperblock();
 
     /**
-     * creates one new inode of the superblock adds the dentry sets it in the bitmap
-     * @param dentry the dentry to set in the new inode
+     * creates one new inode of the superblock
      * @param type the file type of the new inode (I_DIR, I_FILE)
      * @return the new inode
      */
-    virtual Inode* createInode(Dentry* dentry, uint32 type);
+    virtual Inode* createInode(uint32 type);
 
     /**
      *  remove the corresponding file descriptor and unlinks it from the inode.

--- a/common/include/fs/minixfs/MinixFSType.h
+++ b/common/include/fs/minixfs/MinixFSType.h
@@ -21,6 +21,6 @@ class MinixFSType : public FileSystemType
      * @param root the root dentry
      * @param s_dev the device number
      */
-    virtual Superblock *createSuper(uint32 s_dev) const;
+    virtual Superblock *createSuper(uint32 s_dev);
 };
 

--- a/common/include/fs/minixfs/MinixFSType.h
+++ b/common/include/fs/minixfs/MinixFSType.h
@@ -21,6 +21,6 @@ class MinixFSType : public FileSystemType
      * @param root the root dentry
      * @param s_dev the device number
      */
-    virtual Superblock *createSuper(Dentry *root, uint32 s_dev) const;
+    virtual Superblock *createSuper(uint32 s_dev) const;
 };
 

--- a/common/include/fs/ramfs/RamFSInode.h
+++ b/common/include/fs/ramfs/RamFSInode.h
@@ -18,95 +18,9 @@ class RamFSInode : public Inode
     virtual ~RamFSInode();
 
     /**
-     * Create a directory with the given dentry.
-     * @param dentry the dentry
-     * @return 0 on success
-     */
-    virtual int32 create ( Dentry *dentry );
-
-    /**
-     * lookup should check if that name (given by the char-array) exists in the
-     * directory (I_DIR inode) and should return the Dentry if it does.
-     * This involves finding and loading the inode. If the lookup failed to find
-     * anything, this is indicated by returning NULL-pointer.
-     * @param name the name
-     * @return the found dentry
-     */
-    virtual Dentry* lookup ( const char *name );
-
-    /**
      * Called when a file is opened
      */
-    virtual File* open(uint32 /*flag*/);
-    /**
-     * Called when the last reference to a file is closed
-     */
-    virtual int32 release(File* /*file*/);
-
-    /**
-     * The link method should make a hard link to the name referred to by the
-     * denty, which is in the directory refered to by the Inode.
-     * (only used for File)
-     * @param flag the flag for the link
-     * @return the link
-     */
-    // virtual File* link ( uint32 flag );
-
-    /**
-     * This should remove the name refered to by the Dentry from the directory
-     * referred to by the inode. (only used for File)
-     * @param file the file to unlink
-     * @return 0 on success
-     */
-    // virtual int32 unlink ( File* file );
-
-    /**
-     * Create a directory with the given dentry. It is only used to with directory.
-     * @param dentry the dentry
-     * @return 0 on success
-     */
-    virtual int32 mkdir ( Dentry *dentry );
-
-    /**
-     * Remove the directory (if the sub_dentry is empty).
-     * @return 0 on success
-     */
-    virtual int32 rmdir();
-
-    /**
-     * Removes the named directory (if empty) or file
-     * @return 0 on success
-     */
-    virtual int32 rm();
-
-    /**
-     * Creates a directory with the given dentry.
-     * @param dentry the dentry
-     * @return 0 on success
-     */
-    virtual int32 mknod ( Dentry *dentry );
-
-    /**
-     * Creates a file with the given dentry.
-     * @param dentry the dentry
-     * @return 0 on success
-     */
-    virtual int32 mkfile ( Dentry *dentry );
-
-    /// The symbolic link referred to by the dentry is read and the value is
-    /// copied into the user buffer (with copy_to_user) with a maximum length
-    /// given by the intege.
-    virtual int32 readlink ( Dentry */*dentry*/, char*, int32 /*max_length*/ ) {return 0;}
-
-    /// If the directory (parent dentry) have a directory and a name within that
-    /// directory (child dentry) then the obvious result of following the name
-    /// from the directory would arrive at the child dentry. If an inode requires
-    /// some other, non-obvious, result - s do symbolic links - the inode should
-    /// provide a follow_link method to return the appropriate new dentry.
-    /// @prt_dentry the parent dentry
-    /// @chd_dentry the child dentry
-    /// @lookup_flags a number of LOOKUP flags
-    virtual Dentry* followLink ( Dentry */*prt_dentry*/, Dentry */*chd_dentry*/ ) {return 0;}
+    virtual File* open(Dentry* dentry, uint32 /*flag*/);
 
     /// read the data from the inode
     /// @param offset offset byte

--- a/common/include/fs/ramfs/RamFSInode.h
+++ b/common/include/fs/ramfs/RamFSInode.h
@@ -35,13 +35,22 @@ class RamFSInode : public Inode
     virtual Dentry* lookup ( const char *name );
 
     /**
+     * Called when a file is opened
+     */
+    virtual File* open(uint32 /*flag*/);
+    /**
+     * Called when the last reference to a file is closed
+     */
+    virtual int32 release(File* /*file*/);
+
+    /**
      * The link method should make a hard link to the name referred to by the
      * denty, which is in the directory refered to by the Inode.
      * (only used for File)
      * @param flag the flag for the link
      * @return the link
      */
-    virtual File* link ( uint32 flag );
+    // virtual File* link ( uint32 flag );
 
     /**
      * This should remove the name refered to by the Dentry from the directory
@@ -49,7 +58,7 @@ class RamFSInode : public Inode
      * @param file the file to unlink
      * @return 0 on success
      */
-    virtual int32 unlink ( File* file );
+    // virtual int32 unlink ( File* file );
 
     /**
      * Create a directory with the given dentry. It is only used to with directory.

--- a/common/include/fs/ramfs/RamFSSuperblock.h
+++ b/common/include/fs/ramfs/RamFSSuperblock.h
@@ -26,14 +26,6 @@ class RamFSSuperblock : public Superblock
     virtual Inode* createInode (uint32 type );
 
     /**
-     * remove the corresponding file descriptor.
-     * @param inode the inode from which to remove the fd from
-     * @param fd the fd to remove
-     * @return 0 on success
-     */
-    virtual int32 removeFd ( Inode* inode, FileDescriptor* fd );
-
-    /**
      * This method is called to read a specific inode from a mounted file-system.
      * @param inode the inode to read
      * @return 0 on success
@@ -56,15 +48,6 @@ class RamFSSuperblock : public Superblock
      * @param inode the inode to delete
      */
     virtual void deleteInode ( Inode* inode );
-
-    /**
-     * create a file with the given flag and a file descriptor with the given
-     * inode.
-     * @param inode the inode to create the fd for
-     * @param flag the flag
-     * @return the file descriptor
-     */
-    virtual int32 createFd ( Inode* inode, uint32 flag );
 };
 //-----------------------------------------------------------------------------
 

--- a/common/include/fs/ramfs/RamFSSuperblock.h
+++ b/common/include/fs/ramfs/RamFSSuperblock.h
@@ -55,7 +55,7 @@ class RamFSSuperblock : public Superblock
      * used.
      * @param inode the inode to delete
      */
-    virtual void delete_inode ( Inode* inode );
+    virtual void deleteInode ( Inode* inode );
 
     /**
      * create a file with the given flag and a file descriptor with the given

--- a/common/include/fs/ramfs/RamFSSuperblock.h
+++ b/common/include/fs/ramfs/RamFSSuperblock.h
@@ -13,7 +13,7 @@ class RamFSSuperblock : public Superblock
      * @param s_root the root dentry of the new filesystem
      * @param s_dev the device number of the new filesystem
      */
-    RamFSSuperblock ( Dentry* s_root, uint32 s_dev );
+    RamFSSuperblock (uint32 s_dev );
     virtual ~RamFSSuperblock();
 
     /**

--- a/common/include/fs/ramfs/RamFSSuperblock.h
+++ b/common/include/fs/ramfs/RamFSSuperblock.h
@@ -22,7 +22,7 @@ class RamFSSuperblock : public Superblock
      * @param type the inode type
      * @return the inode
      */
-    virtual Inode* createInode ( Dentry* dentry, uint32 type );
+    virtual Inode* createInode (uint32 type );
 
     /**
      * remove the corresponding file descriptor.

--- a/common/include/fs/ramfs/RamFSSuperblock.h
+++ b/common/include/fs/ramfs/RamFSSuperblock.h
@@ -4,6 +4,7 @@
 
 class Inode;
 class Superblock;
+class RamFSType;
 
 class RamFSSuperblock : public Superblock
 {
@@ -13,7 +14,7 @@ class RamFSSuperblock : public Superblock
      * @param s_root the root dentry of the new filesystem
      * @param s_dev the device number of the new filesystem
      */
-    RamFSSuperblock (uint32 s_dev );
+    RamFSSuperblock (RamFSType* type, uint32 s_dev );
     virtual ~RamFSSuperblock();
 
     /**

--- a/common/include/fs/ramfs/RamFSType.h
+++ b/common/include/fs/ramfs/RamFSType.h
@@ -20,6 +20,6 @@ class RamFSType : public FileSystemType
      * Creates an Superblock object for the actual file system type.
      * @return a pointer to the Superblock object
      */
-    virtual Superblock *createSuper(uint32 s_dev) const;
+    virtual Superblock *createSuper(uint32 s_dev);
 };
 

--- a/common/include/fs/ramfs/RamFSType.h
+++ b/common/include/fs/ramfs/RamFSType.h
@@ -20,6 +20,6 @@ class RamFSType : public FileSystemType
      * Creates an Superblock object for the actual file system type.
      * @return a pointer to the Superblock object
      */
-    virtual Superblock *createSuper(Dentry *root, uint32 s_dev) const;
+    virtual Superblock *createSuper(uint32 s_dev) const;
 };
 

--- a/common/source/fs/BDManager.cpp
+++ b/common/source/fs/BDManager.cpp
@@ -66,6 +66,11 @@ BDVirtualDevice* BDManager::getDeviceByNumber(uint32 dev_num)
 
 BDVirtualDevice* BDManager::getDeviceByName(const char * dev_name)
 {
+  if(!dev_name)
+  {
+      return 0;
+  }
+
   debug(BD_MANAGER, "getDeviceByName: %s", dev_name);
   for (BDVirtualDevice* dev : device_list_)
   {

--- a/common/source/fs/Dentry.cpp
+++ b/common/source/fs/Dentry.cpp
@@ -4,16 +4,19 @@
 
 #include "kprintf.h"
 
-Dentry::Dentry(const char* name) :
-    d_inode_(0), d_parent_(this), d_mounts_(0), d_name_(name)
+Dentry::Dentry(Inode* inode) :
+    d_inode_(inode), d_parent_(this), d_mounts_(0), d_name_("/")
 {
-  debug(DENTRY, "created Dentry with Name %s\n", name);
+    debug(DENTRY, "Created root Dentry\n");
+    inode->incLinkCount();
 }
 
-Dentry::Dentry(Dentry *parent) :
-    d_inode_(0), d_parent_(parent), d_mounts_(0), d_name_("NamELLEss")
+Dentry::Dentry(Inode* inode, Dentry* parent, const ustl::string& name) :
+    d_inode_(inode), d_parent_(parent), d_mounts_(0), d_name_(name)
 {
-  parent->setChild(this);
+    debug(DENTRY, "created Dentry with Name %s\n", name.c_str());
+    parent->setChild(this);
+    inode->incLinkCount();
 }
 
 Dentry::~Dentry()

--- a/common/source/fs/Dentry.cpp
+++ b/common/source/fs/Dentry.cpp
@@ -22,15 +22,13 @@ Dentry::Dentry(Inode* inode, Dentry* parent, const ustl::string& name) :
 
 Dentry::~Dentry()
 {
-  debug(DENTRY, "deleting Dentry with Name %s, d_parent_: %p, this: %p\n", d_name_.c_str(), d_parent_, this);
+  debug(DENTRY, "Deleting Dentry %s, d_parent_: %p, this: %p\n", d_name_.c_str(), d_parent_, this);
   if (d_parent_ && (d_parent_ != this))
   {
-    debug(DENTRY, "deleting Dentry child remove d_parent_: %p\n", d_parent_);
     d_parent_->childRemove(this);
   }
   for (Dentry* dentry : d_child_)
     dentry->d_parent_ = 0;
-  debug(DENTRY, "deleting Dentry finished\n");
 }
 
 void Dentry::setInode(Inode *inode)
@@ -49,9 +47,9 @@ int32 Dentry::childRemove(Dentry *child_dentry)
   debug(DENTRY, "Dentry childRemove d_child_ included: %d\n",
         ustl::find(d_child_.begin(), d_child_.end(), child_dentry) != d_child_.end());
   assert(child_dentry != 0);
+  assert(child_dentry->d_parent_ == this);
   d_child_.remove(child_dentry);
   child_dentry->d_parent_ = 0;
-  debug(DENTRY, "Dentry childRemove remove == 0\n");
   return 0;
 }
 

--- a/common/source/fs/Dentry.cpp
+++ b/common/source/fs/Dentry.cpp
@@ -15,6 +15,7 @@ Dentry::Dentry(Inode* inode, Dentry* parent, const ustl::string& name) :
     d_inode_(inode), d_parent_(parent), d_mounts_(0), d_name_(name)
 {
     debug(DENTRY, "created Dentry with Name %s\n", name.c_str());
+    assert(name != "");
     parent->setChild(this);
     inode->incLinkCount();
 }

--- a/common/source/fs/Dentry.cpp
+++ b/common/source/fs/Dentry.cpp
@@ -8,7 +8,7 @@ Dentry::Dentry(Inode* inode) :
     d_inode_(inode), d_parent_(this), d_mounts_(0), d_name_("/")
 {
     debug(DENTRY, "Created root Dentry\n");
-    inode->incLinkCount();
+    inode->addDentry(this);
 }
 
 Dentry::Dentry(Inode* inode, Dentry* parent, const ustl::string& name) :
@@ -17,7 +17,7 @@ Dentry::Dentry(Inode* inode, Dentry* parent, const ustl::string& name) :
     debug(DENTRY, "created Dentry with Name %s\n", name.c_str());
     assert(name != "");
     parent->setChild(this);
-    inode->incLinkCount();
+    inode->addDentry(this);
 }
 
 Dentry::~Dentry()
@@ -29,6 +29,8 @@ Dentry::~Dentry()
   }
   for (Dentry* dentry : d_child_)
     dentry->d_parent_ = 0;
+
+  d_inode_->removeDentry(this);
 }
 
 void Dentry::setInode(Inode *inode)

--- a/common/source/fs/File.cpp
+++ b/common/source/fs/File.cpp
@@ -1,9 +1,28 @@
 #include "File.h"
 #include "Inode.h"
+#include "FileDescriptor.h"
+#include "assert.h"
+
 
 File::File(Inode* inode, Dentry* dentry, uint32 flag) :
     uid(0), gid(0), version(0), f_superblock_(0), f_inode_(inode), f_dentry_(dentry), flag_(flag)
 {
+}
+
+File::~File()
+{
+  debug(VFS_FILE, "Destroying file\n");
+
+  if(!f_fds_.empty())
+  {
+    debug(VFS_FILE, "WARNING: File still has open file descriptors\n");
+  }
+
+  for(FileDescriptor* fd : f_fds_)
+  {
+    fd->file_ = nullptr;
+    delete fd;
+  }
 }
 
 uint32 File::getSize()
@@ -23,4 +42,36 @@ l_off_t File::lseek(l_off_t offset, uint8 origin)
     return -1;
 
   return offset_;
+}
+
+
+
+
+FileDescriptor* File::openFd()
+{
+    debug(VFS_FILE, "Open new file descriptor\n");
+    FileDescriptor* fd = new FileDescriptor(this);
+    f_fds_.push_back(fd);
+
+    debug(VFS_FILE, "New file descriptor num: %u\n", fd->getFd());
+    return fd;
+}
+
+
+int File::closeFd(FileDescriptor* fd)
+{
+    debug(VFS_FILE, "Close file descriptor num %u\n", fd->getFd());
+    assert(fd);
+
+    f_fds_.remove(fd);
+    delete fd;
+
+    // Release on last fd removed
+    if(f_fds_.empty())
+    {
+        debug(VFS_FILE, "Releasing file\n");
+        return getInode()->release(this); // Will delete this file object
+    }
+
+    return 0;
 }

--- a/common/source/fs/FileSystemInfo.cpp
+++ b/common/source/fs/FileSystemInfo.cpp
@@ -4,13 +4,12 @@
 #include "assert.h"
 
 FileSystemInfo::FileSystemInfo() :
-    root_(0), root_mnt_(0), pwd_(0), pwd_mnt_(0), alt_root_(0), alt_root_mnt_(0)
+    root_(), pwd_()
 {
 }
 
 FileSystemInfo::FileSystemInfo(const FileSystemInfo& fsi) :
-    root_(fsi.root_), root_mnt_(fsi.root_mnt_), pwd_(fsi.pwd_), pwd_mnt_(fsi.pwd_mnt_), alt_root_(fsi.alt_root_),
-    alt_root_mnt_(0)
+    root_(fsi.root_),pwd_(fsi.pwd_)
 {
 }
 

--- a/common/source/fs/FileSystemType.cpp
+++ b/common/source/fs/FileSystemType.cpp
@@ -21,18 +21,3 @@ int32 FileSystemType::getFSFlags() const
 {
   return fs_flags_;
 }
-
-
-Superblock *FileSystemType::readSuper ( Superblock* /*superblock*/, void* /*data*/ ) const
-{
-  assert ( 0 );
-  return ( 0 );
-}
-
-
-Superblock *FileSystemType::createSuper ( Dentry* /*dentry*/, uint32 /*s_dev*/ ) const
-{
-  assert ( 0 );
-  return ( Superblock* ) 0;
-}
-

--- a/common/source/fs/FileSystemType.cpp
+++ b/common/source/fs/FileSystemType.cpp
@@ -1,4 +1,4 @@
-#include "fs/FileSystemType.h"
+#include "FileSystemType.h"
 #include "assert.h"
 
 FileSystemType::FileSystemType(const char *fs_name) :

--- a/common/source/fs/Inode.cpp
+++ b/common/source/fs/Inode.cpp
@@ -1,0 +1,232 @@
+#include "Inode.h"
+#include "Superblock.h"
+#include "FileSystemType.h"
+#include "File.h"
+
+Inode::Inode(Superblock *superblock, uint32 inode_type) :
+    i_dentrys_(),
+    i_files_(),
+    i_nlink_(0),
+    i_refcount_(0),
+    superblock_(superblock),
+    i_size_(0),
+    i_type_(inode_type),
+    i_state_(I_UNUSED),
+    i_mode_((A_READABLE ^ A_WRITABLE) ^ A_EXECABLE)
+{
+}
+
+Inode::~Inode()
+{
+    if(i_refcount_ != 0)
+    {
+        debug(INODE, "~Inode %s %p refcount: %u\n", getSuperblock()->getFSType()->getFSName(), this, i_refcount_.load());
+    }
+    assert(i_refcount_ == 0);
+}
+
+uint32 Inode::incRefCount()
+{
+    auto count = ++i_refcount_;
+    debug(INODE, "Increasing %s inode %p ref count to: %u\n", getSuperblock()->getFSType()->getFSName(), this, count);
+    return count;
+}
+
+uint32 Inode::decRefCount()
+{
+    auto count = --i_refcount_;
+    debug(INODE, "Decreasing %s inode %p ref count to: %u\n", getSuperblock()->getFSType()->getFSName(), this, count);
+    return count;
+}
+
+uint32 Inode::incLinkCount()
+{
+    auto count = ++i_nlink_;
+    debug(INODE, "Increasing %s inode %p link count to: %u\n", getSuperblock()->getFSType()->getFSName(), this, count);
+    return count;
+}
+
+uint32 Inode::decLinkCount()
+{
+    auto count = --i_nlink_;
+    debug(INODE, "Decreasing %s inode %p link count to: %u\n", getSuperblock()->getFSType()->getFSName(), this, count);
+    return count;
+}
+
+uint32 Inode::numRefs()
+{
+    return i_refcount_.load();
+}
+
+
+bool Inode::hasDentry(Dentry* dentry)
+{
+    return ustl::find(i_dentrys_.begin(), i_dentrys_.end(), dentry) != i_dentrys_.end();
+}
+
+void Inode::addDentry(Dentry* dentry)
+{
+    assert(dentry);
+    assert(!hasDentry(dentry));
+
+    debug(INODE, "%s inode %p addDentry %s\n",
+          getSuperblock()->getFSType()->getFSName(), this, dentry->getName());
+
+    incRefCount();
+
+    i_dentrys_.push_back(dentry);
+    dentry->setInode(this);
+}
+
+void Inode::removeDentry(Dentry* dentry)
+{
+    assert(dentry);
+    assert(dentry->getInode() == this);
+    assert(hasDentry(dentry));
+
+    debug(INODE, "%s inode %p removeDentry %s\n",
+          getSuperblock()->getFSType()->getFSName(), this, dentry->getName());
+
+    i_dentrys_.remove(dentry);
+    assert(!hasDentry(dentry));
+
+    dentry->releaseInode();
+    decRefCount();
+}
+
+
+
+// ########################
+// Default inode operations
+// ########################
+
+int32 Inode::mkfile(Dentry* dentry)
+{
+    assert(dentry);
+    assert(dentry->getInode() == this);
+    assert(hasDentry(dentry));
+    assert(getType() == I_FILE);
+
+    debug(INODE, "%s inode %p mkfile %s\n",
+          getSuperblock()->getFSType()->getFSName(), this, dentry->getName());
+
+    incLinkCount();
+    return 0;
+}
+
+int32 Inode::mkdir(Dentry* dentry)
+{
+    assert(dentry);
+    assert(dentry->getInode() == this);
+    assert(hasDentry(dentry));
+    assert(getType() == I_DIR);
+
+    debug(INODE, "%s inode %p mkdir %s\n",
+          getSuperblock()->getFSType()->getFSName(), this, dentry->getName());
+
+    incLinkCount();
+    return 0;
+}
+
+int32 Inode::mknod(Dentry* dentry)
+{
+    assert(dentry);
+    assert(dentry->getInode() == this);
+    assert(hasDentry(dentry));
+    assert((getType() != I_DIR) && (getType() != I_FILE));
+
+    debug(INODE, "%s inode %p mkdir %s\n",
+          getSuperblock()->getFSType()->getFSName(), this, dentry->getName());
+
+    incLinkCount();
+    return 0;
+}
+
+int32 Inode::link(Dentry* dentry)
+{
+    assert(dentry);
+    assert(dentry->getInode() == this);
+    assert(hasDentry(dentry));
+
+    if(getType() == I_DIR)
+    {
+        debug(INODE, "Hard links are not supported for directories\n");
+        return -1;
+    }
+
+    debug(INODE, "%s indode %p link %s\n",
+          getSuperblock()->getFSType()->getFSName(), this, dentry->getName());
+
+    incLinkCount();
+    return 0;
+}
+
+int32 Inode::unlink(Dentry* dentry)
+{
+    assert(dentry);
+    assert(dentry->getInode() == this);
+    assert(hasDentry(dentry));
+
+    debug(INODE, "%s inode %p unlink %s\n",
+          getSuperblock()->getFSType()->getFSName(), this, dentry->getName());
+
+    if(!dentry->emptyChild())
+    {
+        debug(INODE, "Error: %s inode %p has children, cannot unlink %s\n",
+              getSuperblock()->getFSType()->getFSName(), this, dentry->getName());
+        return -1;
+    }
+
+    decLinkCount();
+    return 0;
+}
+
+int32 Inode::rmdir(Dentry* dentry)
+{
+    assert(dentry);
+    assert(dentry->getInode() == this);
+    assert(hasDentry(dentry));
+    assert(getType() == I_DIR);
+
+    debug(INODE, "%s inode %p rmdir %s\n",
+          getSuperblock()->getFSType()->getFSName(), this, dentry->getName());
+
+    if(!dentry->emptyChild())
+    {
+        debug(INODE, "Error: %s inode %p has children, cannot unlink %s\n",
+              getSuperblock()->getFSType()->getFSName(), this, dentry->getName());
+        return -1;
+    }
+
+    decLinkCount();
+    return 0;
+}
+
+Dentry* Inode::lookup(const char* name)
+{
+    if (name == 0)
+    {
+        // ERROR_DNE
+        return 0;
+    }
+
+    debug(INODE, "%s inode %p lookup %s\n", getSuperblock()->getFSType()->getFSName(), this, name);
+
+    if (i_type_ != I_DIR)
+    {
+        return 0;
+    }
+
+    assert(i_dentrys_.size() >= 1);
+    return i_dentrys_.front()->checkName(name);
+}
+
+
+int32 Inode::release(File* file)
+{
+    debug(INODE, "%s inode %p release file\n", getSuperblock()->getFSType()->getFSName(), this);
+    i_files_.remove(file);
+    getSuperblock()->fileReleased(file);
+    delete file;
+    return 0;
+}

--- a/common/source/fs/Path.cpp
+++ b/common/source/fs/Path.cpp
@@ -1,4 +1,8 @@
 #include "Path.h"
+#include "kprintf.h"
+#include "debug.h"
+#include "Dentry.h"
+#include "VfsMount.h"
 
 Path::Path(Dentry* dentry, VfsMount* mnt) :
     dentry_(dentry), mnt_(mnt)
@@ -10,4 +14,55 @@ Path::Path(Dentry* dentry, VfsMount* mnt) :
 bool Path::operator==(const Path& other) const
 {
     return ((dentry_ == other.dentry_) && (mnt_ == other.mnt_));
+}
+
+
+Path Path::parentDir(const Path* global_root) const
+{
+    if(isGlobalRoot(global_root))
+    {
+        debug(PATHWALKER, "Reached global file system root\n");
+        return *this;
+    }
+
+    if(dentry_->getParent() == dentry_)
+    {
+        debug(PATHWALKER, "File system mount root reached, going up a mount to vfsmount %p, mountpoint %p %s\n", mnt_->getParent(), mnt_->getMountPoint(), mnt_->getMountPoint()->getName());
+
+        return Path(mnt_->getMountPoint()->getParent(), mnt_->getParent());
+    }
+
+    return Path(dentry_->getParent(), mnt_);
+}
+
+
+ustl::string Path::getAbsolutePath(const Path* global_root) const
+{
+    if(isGlobalRoot(global_root))
+    {
+        return "/";
+    }
+    else if(isMountRoot()) // If this is a mount root, we want the name of the mountpoint instead
+    {
+        return parentDir().getAbsolutePath() + mnt_->getMountPoint()->getName();
+    }
+    else if(parentDir().isGlobalRoot()) // Avoid adding '/' twice
+    {
+        return parentDir().getAbsolutePath() + dentry_->getName();
+    }
+    else
+    {
+        return parentDir().getAbsolutePath() + "/" + dentry_->getName();
+    }
+}
+
+bool Path::isGlobalRoot(const Path* global_root) const
+{
+    return (global_root && (*this == *global_root)) ||
+        (isMountRoot() && mnt_->isRootMount());
+}
+
+bool Path::isMountRoot() const
+{
+    return dentry_->getParent() == dentry_;
 }

--- a/common/source/fs/Path.cpp
+++ b/common/source/fs/Path.cpp
@@ -3,6 +3,10 @@
 #include "debug.h"
 #include "Dentry.h"
 #include "VfsMount.h"
+#include "Inode.h"
+#include "assert.h"
+#include "VirtualFileSystem.h"
+#include "PathWalker.h"
 
 Path::Path(Dentry* dentry, VfsMount* mnt) :
     dentry_(dentry), mnt_(mnt)
@@ -17,15 +21,18 @@ bool Path::operator==(const Path& other) const
 }
 
 
-Path Path::parentDir(const Path* global_root) const
+Path Path::parent(const Path* global_root) const
 {
+    debug(PATHWALKER, "Walk up to parent dir\n");
+    assert(dentry_ && mnt_);
+
     if(isGlobalRoot(global_root))
     {
         debug(PATHWALKER, "Reached global file system root\n");
         return *this;
     }
 
-    if(dentry_->getParent() == dentry_)
+    if(isMountRoot())
     {
         debug(PATHWALKER, "File system mount root reached, going up a mount to vfsmount %p, mountpoint %p %s\n", mnt_->getParent(), mnt_->getMountPoint(), mnt_->getMountPoint()->getName());
 
@@ -33,6 +40,36 @@ Path Path::parentDir(const Path* global_root) const
     }
 
     return Path(dentry_->getParent(), mnt_);
+}
+
+int Path::child(const ustl::string& name, Path& out) const
+{ // Warning: out parameter may refer to this object!
+    debug(PATHWALKER, "Walk down to child %s\n", name.c_str());
+    assert(dentry_ && mnt_);
+
+    VfsMount* child_mnt = mnt_;
+    Dentry *child_dentry = dentry_->getInode()->lookup(name.c_str());
+    if(!child_dentry)
+    {
+        debug(PATHWALKER, "Error: No child dentry %s\n", name.c_str());
+        out = Path();
+        return PW_ENOTFOUND;
+    }
+
+#ifndef EXE2MINIXFS
+    VfsMount* vfs_mount = vfs.getVfsMount(child_dentry);
+    if (vfs_mount != 0)
+    {
+        debug(PATHWALKER, "Reached mountpoint at %s, going down to mounted file system\n", dentry_->getName());
+        assert(child_dentry->getMountedRoot() == vfs_mount->getRoot());
+
+        child_dentry = vfs_mount->getRoot();
+        child_mnt = vfs_mount;
+    }
+#endif
+
+    out = Path(child_dentry, child_mnt);
+    return PW_SUCCESS;
 }
 
 
@@ -44,15 +81,15 @@ ustl::string Path::getAbsolutePath(const Path* global_root) const
     }
     else if(isMountRoot()) // If this is a mount root, we want the name of the mountpoint instead
     {
-        return parentDir().getAbsolutePath() + mnt_->getMountPoint()->getName();
+        return parent().getAbsolutePath() + mnt_->getMountPoint()->getName();
     }
-    else if(parentDir().isGlobalRoot()) // Avoid adding '/' twice
+    else if(parent().isGlobalRoot()) // Avoid adding '/' twice
     {
-        return parentDir().getAbsolutePath() + dentry_->getName();
+        return parent().getAbsolutePath() + dentry_->getName();
     }
     else
     {
-        return parentDir().getAbsolutePath() + "/" + dentry_->getName();
+        return parent().getAbsolutePath() + "/" + dentry_->getName();
     }
 }
 

--- a/common/source/fs/Path.cpp
+++ b/common/source/fs/Path.cpp
@@ -1,0 +1,13 @@
+#include "Path.h"
+
+Path::Path(Dentry* dentry, VfsMount* mnt) :
+    dentry_(dentry), mnt_(mnt)
+{
+
+}
+
+
+bool Path::operator==(const Path& other) const
+{
+    return ((dentry_ == other.dentry_) && (mnt_ == other.mnt_));
+}

--- a/common/source/fs/PathWalker.cpp
+++ b/common/source/fs/PathWalker.cpp
@@ -40,6 +40,12 @@ int32 PathWalker::pathWalk(const char* pathname, const Path& pwd, const Path& ro
 
   debug(PATHWALKER, "pathWalk> path: %s\n", pathname);
 
+  if (strlen(pathname) == 0)
+  {
+      debug(PATHWALKER, "pathWalk> ERROR: Empty path name\n");
+      return PW_EINVALID;
+  }
+
   if ((pwd.dentry_ == 0) || (pwd.mnt_ == 0))
   {
       debug(PATHWALKER, "pathWalk> Error: Invalid pwd\n");
@@ -246,6 +252,9 @@ ustl::string PathWalker::pathPrefix(const ustl::string& path)
 
 ustl::string PathWalker::lastPathSegment(const ustl::string& path, bool ignore_separator_at_end)
 {
+    if(path.length() == 0)
+        return path;
+
     if(!ignore_separator_at_end || path.back() != '/')
     {
         ssize_t prefix_len = path.find_last_of("/");
@@ -255,7 +264,7 @@ ustl::string PathWalker::lastPathSegment(const ustl::string& path, bool ignore_s
     }
     else
     {
-        ustl::string tmp_path = path.substr(0, tmp_path.find_last_not_of("/"));
+        ustl::string tmp_path = path.substr(0, path.find_last_not_of("/") + 1);
         ssize_t prefix_len = tmp_path.find_last_of("/");
         ustl::string retval = tmp_path.substr(prefix_len+1, tmp_path.length() - prefix_len);
         debug(PATHWALKER, "lastPathSegment: %s -> %s\n", path.c_str(), retval.c_str());

--- a/common/source/fs/PathWalker.cpp
+++ b/common/source/fs/PathWalker.cpp
@@ -18,6 +18,12 @@
 #define CHAR_ROOT '/'
 #define SEPARATOR '/'
 
+int32 PathWalker::pathWalk(const char* pathname, FileSystemInfo* fs_info, uint32 flags_ __attribute__ ((unused)), Path& out, Path* parent_dir)
+{
+    assert(fs_info);
+    return pathWalk(pathname, fs_info->getPwd(), fs_info->getRoot(), flags_, out, parent_dir);
+}
+
 int32 PathWalker::pathWalk(const char* pathname, const Path& pwd, const Path& root, uint32 flags_ __attribute__ ((unused)), Path& out, Path* parent_dir)
 {
   // Flag indicating the type of the last path component.
@@ -221,5 +227,38 @@ int32 PathWalker::getNextPartLen(const char* path, int32 &npart_len)
     npart_len = strlen(path);
     return npart_len + 1;
   }
+}
 
+
+ustl::string PathWalker::pathPrefix(const ustl::string& path)
+{
+    ssize_t prefix_len = path.find_last_of("/");
+    if(prefix_len == -1)
+    {
+        debug(PATHWALKER, "pathPrefix: %s -> %s\n", path.c_str(), "");
+        return "";
+    }
+
+    ustl::string retval = path.substr(0, prefix_len);
+    debug(PATHWALKER, "pathPrefix: %s -> %s\n", path.c_str(), retval.c_str());
+    return retval;
+}
+
+ustl::string PathWalker::lastPathSegment(const ustl::string& path, bool ignore_separator_at_end)
+{
+    if(!ignore_separator_at_end || path.back() != '/')
+    {
+        ssize_t prefix_len = path.find_last_of("/");
+        ustl::string retval = path.substr(prefix_len+1, path.length() - prefix_len);
+        debug(PATHWALKER, "lastPathSegment: %s -> %s\n", path.c_str(), retval.c_str());
+        return retval;
+    }
+    else
+    {
+        ustl::string tmp_path = path.substr(0, tmp_path.find_last_not_of("/"));
+        ssize_t prefix_len = tmp_path.find_last_of("/");
+        ustl::string retval = tmp_path.substr(prefix_len+1, tmp_path.length() - prefix_len);
+        debug(PATHWALKER, "lastPathSegment: %s -> %s\n", path.c_str(), retval.c_str());
+        return retval;
+    }
 }

--- a/common/source/fs/PathWalker.cpp
+++ b/common/source/fs/PathWalker.cpp
@@ -18,21 +18,17 @@
 #define CHAR_ROOT '/'
 #define SEPARATOR '/'
 
-int32 PathWalker::pathWalk(const char* pathname, FileSystemInfo* fs_info, uint32 flags_ __attribute__ ((unused)), Path& out, Path* parent_dir)
+
+
+int32 PathWalker::pathWalk(const char* pathname, FileSystemInfo* fs_info, Path& out, Path* parent_dir)
 {
-    assert(fs_info);
-    return pathWalk(pathname, fs_info->getPwd(), fs_info->getRoot(), flags_, out, parent_dir);
+  assert(fs_info);
+  return pathWalk(pathname, fs_info->getPwd(), fs_info->getRoot(), out, parent_dir);
 }
 
-int32 PathWalker::pathWalk(const char* pathname, const Path& pwd, const Path& root, uint32 flags_ __attribute__ ((unused)), Path& out, Path* parent_dir)
+int32 PathWalker::pathWalk(const char* pathname, const Path& pwd, const Path& root, Path& out, Path* parent_dir)
 {
-  // Flag indicating the type of the last path component.
-  int32 last_type_ = 0;
-
-  // The last path component
-  char* last_ = 0;
-
-  if (pathname == 0)
+  if ((pathname == 0) || (strlen(pathname) == 0))
   {
     debug(PATHWALKER, "pathWalk> ERROR: Invalid path name\n");
     return PW_EINVALID;
@@ -40,21 +36,10 @@ int32 PathWalker::pathWalk(const char* pathname, const Path& pwd, const Path& ro
 
   debug(PATHWALKER, "pathWalk> path: %s\n", pathname);
 
-  if (strlen(pathname) == 0)
+  if ((pwd.dentry_ == 0) || (pwd.mnt_ == 0) ||
+      (root.dentry_ == 0) || (root.mnt_ == 0))
   {
-      debug(PATHWALKER, "pathWalk> ERROR: Empty path name\n");
-      return PW_EINVALID;
-  }
-
-  if ((pwd.dentry_ == 0) || (pwd.mnt_ == 0))
-  {
-      debug(PATHWALKER, "pathWalk> Error: Invalid pwd\n");
-      return PW_EINVALID;
-  }
-
-  if ((root.dentry_ == 0) || (root.mnt_ == 0))
-  {
-      debug(PATHWALKER, "pathWalk> Error: Invalid root\n");
+      debug(PATHWALKER, "pathWalk> Error: Invalid pwd/root\n");
       return PW_EINVALID;
   }
 
@@ -64,175 +49,86 @@ int32 PathWalker::pathWalk(const char* pathname, const Path& pwd, const Path& ro
     *parent_dir = Path();
   }
 
-  // check the first character of the path
-  if (*pathname == CHAR_ROOT)
-  {
-    // Start at ROOT
-    last_type_ = LAST_ROOT;
-    out = root;
-  }
-  else
-  {
-    // Start at PWD
-    out = pwd;
-  }
-
-
+  // Start at ROOT if path starts with '/', else start with PWD
+  out = (*pathname == CHAR_ROOT) ? root : pwd;
   debug(PATHWALKER, "PathWalk> Start dentry: %p, vfs_mount: %p\n", out.dentry_, out.mnt_);
 
-  while (*pathname == SEPARATOR)
-    pathname++;
-  if (!*pathname) // i.e. path = /
+
+  while (true)
   {
-    debug(PATHWALKER, "pathWalk> return 0 pathname == /\n");
-    if(parent_dir)
-    {
-      *parent_dir = out;
-    }
-    return PW_SUCCESS;
-  }
-
-  bool parts_left = true;
-  while (parts_left)
-  {
-    int32 npart_pos = 0;
-    int32 npart_len = getNextPartLen(pathname, npart_pos);
-    char npart[npart_len];
-    strncpy(npart, pathname, npart_len);
-    npart[npart_len - 1] = 0;
-    debug(PATHWALKER, "pathWalk> remaining: %s\n", pathname);
-    debug(PATHWALKER, "pathWalk> npart: %s\n", npart);
-    debug(PATHWALKER, "pathWalk> npart_len: %d, npart_pos: %d\n", npart_len, npart_pos);
-    if (npart_pos < 0)
-    {
-      debug(PATHWALKER, "pathWalk> return path invalid npart_pos < 0 \n");
-      return PW_EINVALID;
-    }
-
-    if ((*npart == NULL_CHAR) || (npart_pos == 0))
-    {
-      debug(PATHWALKER, "pathWalk> path == \\0\n");
-      break;
-    }
-    pathname += npart_pos;
-
-    last_ = npart;
-    if (*npart == CHAR_DOT)
-    {
-      if (*(npart + 1) == NULL_CHAR)
-      {
-        last_type_ = LAST_DOT;
-      }
-      else if ((*(npart + 1) == CHAR_DOT) && (*(npart + 2) == NULL_CHAR))
-      {
-        last_type_ = LAST_DOTDOT;
-      }
-    }
-    else
-    {
-      last_type_ = LAST_NORM;
-    }
-
-    // follow the inode
-    // check the VfsMount
-    if (last_type_ == LAST_DOT) // follow LAST_DOT
-    {
-      debug(PATHWALKER, "pathWalk> follow last dot\n");
-      last_ = 0;
-      continue;
-    }
-    else if (last_type_ == LAST_DOTDOT) // follow LAST_DOTDOT
-    {
-      debug(PATHWALKER, "pathWalk> follow last dotdot\n");
-      last_ = 0;
-
-      if(out.isGlobalRoot(&root))
-      {
-        debug(PATHWALKER, "pathWalk> Reached global file system root\n");
-        continue;
-      }
-
-#ifndef EXE2MINIXFS
-      if(out.isMountRoot())
-      {
-        debug(PATHWALKER, "pathWalk> file system mount root reached, going up a mount to vfsmount %p, mountpoint %p %s\n", out.mnt_->getParent(), out.mnt_->getMountPoint(), out.mnt_->getMountPoint()->getName());
-
-        out.dentry_ = out.mnt_->getMountPoint();
-        out.mnt_ = out.mnt_->getParent();
-      }
-#endif
-      out.dentry_ = out.dentry_->getParent();
-      continue;
-    }
-    else if (last_type_ == LAST_NORM) // follow LAST_NORM
-    {
-      debug(PATHWALKER, "pathWalk> follow last norm last_: %s\n", last_);
-      Inode* current_inode = out.dentry_->getInode();
-      Dentry *found = current_inode->lookup(last_);
-      if(!found)
-      {
-        debug(PATHWALKER, "pathWalk> dentry %s not found\n", last_);
-        if(!*pathname && parent_dir) // No further remaining segments -> parent directory exists
-        {
-          *parent_dir = out;
-        }
-        return PW_ENOTFOUND;
-      }
-
-      debug(PATHWALKER, "pathWalk> found dentry %s\n", found->getName());
-
-      last_ = 0;
-      out.dentry_ = found;
-
-#ifndef EXE2MINIXFS
-      VfsMount* vfs_mount = vfs.getVfsMount(out.dentry_);
-      if (vfs_mount != 0)
-      {
-        debug(PATHWALKER, "Reached mountpoint at %s, going down to mounted file system\n", out.dentry_->getName());
-        assert(out.dentry_->getMountedRoot() == vfs_mount->getRoot());
-
-        out.mnt_ = vfs_mount;
-        out.dentry_ = vfs_mount->getRoot();
-      }
-#endif
-    }
-
     while (*pathname == SEPARATOR)
       pathname++;
 
-    if (strlen(pathname) == 0)
+    if (!*pathname)
     {
+      debug(PATHWALKER, "pathWalk> Reached end of path\n");
       break;
     }
+
+    size_t segment_len = getNextPartLen(pathname);
+
+    char segment[segment_len + 1];
+    strncpy(segment, pathname, segment_len + 1);
+    segment[segment_len] = 0;
+
+    pathname += segment_len;
+
+    while (*pathname == SEPARATOR)
+        pathname++;
+
+
+    debug(PATHWALKER, "pathWalk> segment: %s\n", segment);
+    debug(PATHWALKER, "pathWalk> remaining: %s\n", pathname);
+
+    switch(pathSegmentType(segment))
+    {
+    case LAST_DOT:
+        debug(PATHWALKER, "pathWalk> follow last dot\n");
+        break;
+    case LAST_DOTDOT:
+        debug(PATHWALKER, "pathWalk> follow last dotdot\n");
+        out = out.parent(&root);
+        break;
+    case LAST_NORM:
+        debug(PATHWALKER, "pathWalk> follow last norm segment: %s\n", segment);
+
+        Path child;
+        if(out.child(segment, child) != PW_SUCCESS)
+        {
+            debug(PATHWALKER, "pathWalk> dentry %s not found\n", segment);
+            if(!*pathname && parent_dir) // No further remaining segments -> parent directory exists
+            {
+                *parent_dir = out;
+            }
+            return PW_ENOTFOUND;
+        }
+
+        out = child;
+        break;
+    default:
+        assert(false);
+    }
   }
-  debug(PATHWALKER, "pathWalk> return 0 end of function\n");
 
   if(parent_dir)
   {
-    *parent_dir = out.parentDir();
+    *parent_dir = out.parent(&root);
   }
   return PW_SUCCESS;
 }
 
-int32 PathWalker::getNextPartLen(const char* path, int32 &npart_len)
+
+int PathWalker::pathSegmentType(const char* segment)
 {
-  char* tmp = 0;
-  tmp = strchr((char*) path, SEPARATOR);
+    return (strcmp(segment, ".")  == 0) ? LAST_DOT    :
+        (strcmp(segment, "..") == 0) ? LAST_DOTDOT :
+        LAST_NORM;
+}
 
-  if (tmp != 0)
-  {
-    int32 len = (size_t) (tmp - path + 1);
-    npart_len = len;
-    while(path[npart_len] && path[npart_len] == SEPARATOR)
-        ++npart_len;
-
-    return len;
-  }
-  else
-  {
-    npart_len = strlen(path);
-    return npart_len + 1;
-  }
+size_t PathWalker::getNextPartLen(const char* path)
+{
+    const char* sep = strchr(path, SEPARATOR);
+    return sep ? sep - path : strlen(path);
 }
 
 

--- a/common/source/fs/Superblock.cpp
+++ b/common/source/fs/Superblock.cpp
@@ -4,8 +4,8 @@
 #include "Inode.h"
 #include "File.h"
 
-Superblock::Superblock(Dentry* s_root, size_t s_dev) :
-    s_magic_(0), s_type_(0), s_dev_(s_dev), s_flags_(0), s_root_(s_root), mounted_over_(0)
+Superblock::Superblock(size_t s_dev) :
+    s_magic_(0), s_type_(0), s_dev_(s_dev), s_flags_(0), s_root_(0), s_mountpoint_(0)
 {
 }
 
@@ -29,7 +29,12 @@ Dentry* Superblock::getRoot()
 
 Dentry* Superblock::getMountPoint()
 {
-  return mounted_over_;
+  return s_mountpoint_;
+}
+
+void Superblock::setMountPoint(Dentry* mountpoint)
+{
+    s_mountpoint_ = mountpoint;
 }
 
 FileSystemType* Superblock::getFSType()

--- a/common/source/fs/Superblock.cpp
+++ b/common/source/fs/Superblock.cpp
@@ -13,7 +13,7 @@ Superblock::~Superblock()
 {
 }
 
-void Superblock::delete_inode(Inode* inode)
+void Superblock::deleteInode(Inode* inode)
 {
   assert(inode != 0);
   dirty_inodes_.remove(inode);

--- a/common/source/fs/Superblock.cpp
+++ b/common/source/fs/Superblock.cpp
@@ -80,26 +80,28 @@ int Superblock::fileReleased(File* file)
 void Superblock::releaseAllOpenFiles()
 {
     debug(SUPERBLOCK, "Releasing all open files\n");
-    for(File* file : s_files_)
+    while(!s_files_.empty())
     {
+        File* file = s_files_.front();
         file->getInode()->release(file);
     }
 
     assert(s_files_.empty());
 }
 
-
 void Superblock::deleteAllInodes()
 {
     for (Inode* inode : all_inodes_)
     {
+        while(!inode->getDentrys().empty())
+        {
+            delete inode->getDentrys().front();
+        }
+
         debug(SUPERBLOCK, "~Superblock write inode to disc\n");
         writeInode(inode);
 
-        debug(SUPERBLOCK, "~Superblock delete dentry\n");
-        delete inode->getDentry();
-
-        debug(SUPERBLOCK, "~Superblock delete inode\n");
+        debug(SUPERBLOCK, "~Superblock delete inode %p\n", inode);
         delete inode;
     }
 

--- a/common/source/fs/Superblock.cpp
+++ b/common/source/fs/Superblock.cpp
@@ -4,8 +4,8 @@
 #include "Inode.h"
 #include "File.h"
 
-Superblock::Superblock(size_t s_dev) :
-    s_magic_(0), s_type_(0), s_dev_(s_dev), s_flags_(0), s_root_(0), s_mountpoint_(0)
+Superblock::Superblock(FileSystemType* fs_type, size_t s_dev) :
+    s_magic_(0), s_type_(fs_type), s_dev_(s_dev), s_flags_(0), s_root_(0), s_mountpoint_(0)
 {
 }
 

--- a/common/source/fs/Superblock.cpp
+++ b/common/source/fs/Superblock.cpp
@@ -3,14 +3,17 @@
 #include "Dentry.h"
 #include "Inode.h"
 #include "File.h"
+#include "FileSystemType.h"
 
 Superblock::Superblock(FileSystemType* fs_type, size_t s_dev) :
     s_magic_(0), s_type_(fs_type), s_dev_(s_dev), s_flags_(0), s_root_(0), s_mountpoint_(0)
 {
+    debug(SUPERBLOCK, "%s Superblock created\n", s_type_->getFSName());
 }
 
 Superblock::~Superblock()
 {
+    debug(SUPERBLOCK, "%s Superblock destroyed\n", s_type_->getFSName());
 }
 
 void Superblock::deleteInode(Inode* inode)
@@ -40,4 +43,65 @@ void Superblock::setMountPoint(Dentry* mountpoint)
 FileSystemType* Superblock::getFSType()
 {
   return (FileSystemType*) s_type_;
+}
+
+
+int Superblock::fileOpened(File* file)
+{
+    Inode* inode = file->getInode();
+    assert(inode->getSuperblock() == this);
+
+    if(ustl::find(s_files_.begin(), s_files_.end(), file) != s_files_.end())
+    {
+        return -1;
+    }
+
+    s_files_.push_back(file);
+    used_inodes_.push_back(inode);
+
+    return 0;
+}
+
+int Superblock::fileReleased(File* file)
+{
+    Inode* inode = file->getInode();
+    assert(inode->getSuperblock() == this);
+
+    s_files_.remove(file);
+
+    if (inode->getNumOpenedFile() == 0)
+    {
+        used_inodes_.remove(inode);
+    }
+
+    return 0;
+}
+
+void Superblock::releaseAllOpenFiles()
+{
+    debug(SUPERBLOCK, "Releasing all open files\n");
+    for(File* file : s_files_)
+    {
+        file->getInode()->release(file);
+    }
+
+    assert(s_files_.empty());
+}
+
+
+void Superblock::deleteAllInodes()
+{
+    for (Inode* inode : all_inodes_)
+    {
+        debug(SUPERBLOCK, "~Superblock write inode to disc\n");
+        writeInode(inode);
+
+        debug(SUPERBLOCK, "~Superblock delete dentry\n");
+        delete inode->getDentry();
+
+        debug(SUPERBLOCK, "~Superblock delete inode\n");
+        delete inode;
+    }
+
+    all_inodes_.clear();
 }

--- a/common/source/fs/VfsMount.cpp
+++ b/common/source/fs/VfsMount.cpp
@@ -70,3 +70,8 @@ void VfsMount::clear()
   mnt_flags_ = 0;
 }
 
+
+bool VfsMount::isRootMount() const
+{
+    return getParent() == this;
+}

--- a/common/source/fs/VfsMount.cpp
+++ b/common/source/fs/VfsMount.cpp
@@ -12,7 +12,7 @@ VfsMount::VfsMount() :
 
 VfsMount::VfsMount ( VfsMount* parent, Dentry * mountpoint, Dentry* root,
                      Superblock* superblock, int32 flags ) :
-    mnt_parent_ ( parent ),
+    mnt_parent_ ( parent ? parent : this),
     mnt_mountpoint_ ( mountpoint ),
     mnt_root_ ( root ),
     mnt_sb_ ( superblock ),

--- a/common/source/fs/VfsSyscall.cpp
+++ b/common/source/fs/VfsSyscall.cpp
@@ -96,15 +96,15 @@ int32 VfsSyscall::mkdir(const char* pathname, int32)
     return -1;
   }
 
-  // create a new dentry
-  Dentry *sub_dentry = new Dentry(pw_dentry);
-  sub_dentry->d_name_ = sub_dentry_name;
+  Inode* sub_inode = current_sb->createInode(I_DIR);
+  Dentry *sub_dentry = new Dentry(sub_inode, pw_dentry, sub_dentry_name);
+  sub_inode->mkdir(sub_dentry);
+
   debug(VFSSYSCALL, "(mkdir) creating Inode: current_dentry->getName(): %s\n", pw_dentry->getName());
   debug(VFSSYSCALL, "(mkdir) creating Inode: sub_dentry->getName(): %s\n", sub_dentry->getName());
   debug(VFSSYSCALL, "(mkdir) current_sb: %p\n", current_sb);
   debug(VFSSYSCALL, "(mkdir) current_sb->getFSType(): %p\n", current_sb->getFSType());
 
-  current_sb->createInode(sub_dentry, I_DIR);
   debug(VFSSYSCALL, "(mkdir) sub_dentry->getInode(): %p\n", sub_dentry->getInode());
   return 0;
 }
@@ -331,17 +331,16 @@ int32 VfsSyscall::open(const char* pathname, uint32 flag)
       return -1;
     }
 
-    // create a new dentry
-    Dentry *sub_dentry = new Dentry(pw_dentry);
-    sub_dentry->d_name_ = sub_dentry_name;
-    sub_dentry->setParent(pw_dentry);
     debug(VFSSYSCALL, "(open) calling create Inode\n");
-    Inode* sub_inode = current_sb->createInode(sub_dentry, I_FILE);
+    Inode* sub_inode = current_sb->createInode(I_FILE);
     if (!sub_inode)
     {
-      delete sub_dentry;
       return -1;
     }
+
+    Dentry *sub_dentry = new Dentry(sub_inode, pw_dentry, sub_dentry_name);
+    sub_inode->mkfile(sub_dentry);
+
     debug(VFSSYSCALL, "(open) created Inode with dentry name %s\n", sub_inode->getDentry()->getName());
 
     int32 fd = current_sb->createFd(sub_inode, flag);

--- a/common/source/fs/VfsSyscall.cpp
+++ b/common/source/fs/VfsSyscall.cpp
@@ -37,7 +37,7 @@ FileDescriptor* VfsSyscall::getFileDescriptor(uint32 fd)
   return 0;
 }
 
-int32 VfsSyscall::dupChecking(const char* pathname, const Path& pwd, const Path& root, Path& out_path)
+int32 VfsSyscall::dupChecking(const char* pathname, const Path& pwd, const Path& root, Path& out_path, Path* parent_dir)
 {
   FileSystemInfo *fs_info = getcwd();
   assert(fs_info != NULL);
@@ -57,7 +57,7 @@ int32 VfsSyscall::dupChecking(const char* pathname, const Path& pwd, const Path&
   }
   fs_info->pathname_ += pathname;
 
-  return PathWalker::pathWalk(fs_info->pathname_.c_str(), pwd, root, 0, out_path);
+  return PathWalker::pathWalk(fs_info->pathname_.c_str(), pwd, root, 0, out_path, parent_dir);
 }
 
 int32 VfsSyscall::mkdir(const char* pathname, int32)

--- a/common/source/fs/VfsSyscall.cpp
+++ b/common/source/fs/VfsSyscall.cpp
@@ -417,7 +417,10 @@ int32 VfsSyscall::mount(const char *device_name, const char *dir_name, const cha
     assert(vfs.registerFileSystem(new MinixFSType()) == 0);
   }
   else if (!type)
-    return -1; // file system type not known
+  {
+      debug(VFSSYSCALL, "(mount) Unknown file system %s\n", file_system_name);
+      return -1; // file system type not known
+  }
 
   return vfs.mount(device_name, dir_name, file_system_name, flag);
 }

--- a/common/source/fs/VfsSyscall.cpp
+++ b/common/source/fs/VfsSyscall.cpp
@@ -45,7 +45,7 @@ int32 VfsSyscall::mkdir(const char* pathname, int32)
 
   Path target_path;
   Path parent_dir_path;
-  int32 path_walk_status = PathWalker::pathWalk(pathname, fs_info, 0, target_path, &parent_dir_path);
+  int32 path_walk_status = PathWalker::pathWalk(pathname, fs_info, target_path, &parent_dir_path);
 
   if((path_walk_status == PW_ENOTFOUND) && parent_dir_path.dentry_)
   {
@@ -105,7 +105,7 @@ Dirent* VfsSyscall::readdir(const char* pathname)
   FileSystemInfo *fs_info = getcwd();
 
   Path target_path;
-  if (PathWalker::pathWalk(pathname, fs_info, 0, target_path) != PW_SUCCESS)
+  if (PathWalker::pathWalk(pathname, fs_info, target_path) != PW_SUCCESS)
   {
     debug(VFSSYSCALL, "(readdir) ERROR: Path doesn't exist\n");
     kprintf("Error: %s not found\n", pathname);
@@ -136,7 +136,7 @@ int32 VfsSyscall::chdir(const char* pathname)
   FileSystemInfo *fs_info = getcwd();
 
   Path target_path;
-  if (PathWalker::pathWalk(pathname, fs_info, 0, target_path) != PW_SUCCESS)
+  if (PathWalker::pathWalk(pathname, fs_info, target_path) != PW_SUCCESS)
   {
     debug(VFSSYSCALL, "(chdir) Error: The directory does not exist.\n");
     return -1;
@@ -161,7 +161,7 @@ int32 VfsSyscall::rm(const char* pathname)
   FileSystemInfo *fs_info = getcwd();
 
   Path target_path;
-  if (PathWalker::pathWalk(pathname, fs_info, 0, target_path) != PW_SUCCESS)
+  if (PathWalker::pathWalk(pathname, fs_info, target_path) != PW_SUCCESS)
   {
     debug(VFSSYSCALL, "(rm) target file does not exist.\n");
     return -1;
@@ -179,13 +179,12 @@ int32 VfsSyscall::rm(const char* pathname)
   Superblock* sb = current_inode->getSuperblock();
   if (current_inode->rm() == INODE_DEAD)
   {
-    debug(VFSSYSCALL, "(rm() )remove the inode %p from the list of sb: %p\n", current_inode, sb);
+    debug(VFSSYSCALL, "(rm) Remove the inode %p from the list of sb: %p\n", current_inode, sb);
     sb->deleteInode(current_inode);
-    debug(VFSSYSCALL, "(rm) removed\n");
   }
   else
   {
-    debug(VFSSYSCALL, "(rm) remove the inode failed (already marked as dead)\n");
+    debug(VFSSYSCALL, "(rm) Error: Removing the inode failed (already marked as dead)\n");
     return -1;
   }
 
@@ -198,11 +197,11 @@ int32 VfsSyscall::rmdir(const char* pathname)
 
   Path target_dir;
   Path parent_dir_path;
-  int32 path_walk_status = PathWalker::pathWalk(pathname, fs_info, 0, target_dir, &parent_dir_path);
+  int32 path_walk_status = PathWalker::pathWalk(pathname, fs_info, target_dir, &parent_dir_path);
 
   if(path_walk_status != PW_SUCCESS)
   {
-    debug(VFSSYSCALL, "Error: (rmdir) the directory does not exist.\n");
+    debug(VFSSYSCALL, "(rmdir) Error: The directory does not exist.\n");
     return -1;
   }
 
@@ -214,19 +213,19 @@ int32 VfsSyscall::rmdir(const char* pathname)
 
   if (current_inode->getType() != I_DIR)
   {
-    debug(VFSSYSCALL, "This is not a directory\n");
+    debug(VFSSYSCALL, "(rmdir) Error: This is not a directory\n");
     return -1;
   }
 
   Superblock* sb = current_inode->getSuperblock();
   if (current_inode->rmdir() == INODE_DEAD)
   {
-    debug(VFSSYSCALL, "remove the inode from the list\n");
+    debug(VFSSYSCALL, "(rmdir) Removing inode from superblock list\n");
     sb->deleteInode(current_inode);
   }
   else
   {
-    debug(VFSSYSCALL, "remove the inode failed\n");
+    debug(VFSSYSCALL, "(rmdir) Error: Remove the inode failed\n");
     return -1;
   }
 
@@ -271,11 +270,11 @@ int32 VfsSyscall::open(const char* pathname, uint32 flag)
 
   Path target_path;
   Path parent_dir_path;
-  int32 path_walk_status = PathWalker::pathWalk(pathname, fs_info, 0, target_path, &parent_dir_path);
+  int32 path_walk_status = PathWalker::pathWalk(pathname, fs_info, target_path, &parent_dir_path);
 
   if (path_walk_status == PW_SUCCESS)
   {
-    debug(VFSSYSCALL, "(open) Found target file\n");
+    debug(VFSSYSCALL, "(open) Found target file: %s\n", target_path.dentry_->getName());
     Inode* target_inode = target_path.dentry_->getInode();
     Superblock* target_sb = target_inode->getSuperblock();
 

--- a/common/source/fs/VirtualFileSystem.cpp
+++ b/common/source/fs/VirtualFileSystem.cpp
@@ -116,8 +116,8 @@ FileSystemInfo *VirtualFileSystem::rootMount(const char *fs_name, uint32 /*flags
   // fs_info initialize
   FileSystemInfo *fs_info = new FileSystemInfo();
   Path root_path(root, root_mount);
-  fs_info->setFsRoot(root_path);
-  fs_info->setFsPwd(root_path);
+  fs_info->setRoot(root_path);
+  fs_info->setPwd(root_path);
 
   assert(root_mount->getParent() == root_mount);
   assert(root_mount->getMountPoint() == root);
@@ -160,9 +160,8 @@ int32 VirtualFileSystem::mount(const char* dev_name, const char* dir_name, const
   }
 
   // Find mount point
-  fs_info->pathname_ = dir_name;
   Path mountpoint_path;
-  int32 success = PathWalker::pathWalk(fs_info->pathname_.c_str(), fs_info->getPwd(), fs_info->getRoot(), 0, mountpoint_path);
+  int32 success = PathWalker::pathWalk(dir_name, fs_info->getPwd(), fs_info->getRoot(), 0, mountpoint_path);
 
   if (success != 0)
   {
@@ -221,9 +220,8 @@ int32 VirtualFileSystem::umount(const char* dir_name, uint32 /*flags*/)
   if (dir_name == 0)
     return -1;
 
-  fs_info->pathname_ = dir_name;
   Path mountpount_path;
-  int32 success = PathWalker::pathWalk(fs_info->pathname_.c_str(), fs_info->getPwd(), fs_info->getRoot(), 0, mountpount_path);
+  int32 success = PathWalker::pathWalk(dir_name, fs_info->getPwd(), fs_info->getRoot(), 0, mountpount_path);
 
   if (success != 0)
   {
@@ -241,12 +239,12 @@ int32 VirtualFileSystem::umount(const char* dir_name, uint32 /*flags*/)
     if (fs_info->getPwd().dentry_ == mountpount_path.dentry_)
     {
       debug(VFS, "(umount) the mount point exchange\n");
-      fs_info->setFsPwd(Path(mountpount_path.mnt_->getMountPoint(), mountpount_path.mnt_->getParent()));
+      fs_info->setPwd(Path(mountpount_path.mnt_->getMountPoint(), mountpount_path.mnt_->getParent()));
     }
     else
     {
       debug(VFS, "(umount) set PWD NULL\n");
-      fs_info->setFsPwd(Path());
+      fs_info->setPwd(Path());
     }
   }
 

--- a/common/source/fs/VirtualFileSystem.cpp
+++ b/common/source/fs/VirtualFileSystem.cpp
@@ -161,7 +161,7 @@ int32 VirtualFileSystem::mount(const char* dev_name, const char* dir_name, const
 
   // Find mount point
   Path mountpoint_path;
-  int32 success = PathWalker::pathWalk(dir_name, fs_info->getPwd(), fs_info->getRoot(), 0, mountpoint_path);
+  int32 success = PathWalker::pathWalk(dir_name, fs_info->getPwd(), fs_info->getRoot(), mountpoint_path);
 
   if (success != 0)
   {
@@ -221,7 +221,7 @@ int32 VirtualFileSystem::umount(const char* dir_name, uint32 /*flags*/)
     return -1;
 
   Path mountpount_path;
-  int32 success = PathWalker::pathWalk(dir_name, fs_info->getPwd(), fs_info->getRoot(), 0, mountpount_path);
+  int32 success = PathWalker::pathWalk(dir_name, fs_info->getPwd(), fs_info->getRoot(), mountpount_path);
 
   if (success != 0)
   {

--- a/common/source/fs/devicefs/DeviceFSSuperblock.cpp
+++ b/common/source/fs/devicefs/DeviceFSSuperblock.cpp
@@ -20,40 +20,23 @@ const char DeviceFSSuperBlock::DEVICE_ROOT_NAME[] = "dev";
 DeviceFSSuperBlock* DeviceFSSuperBlock::instance_ = 0;
 
 DeviceFSSuperBlock::DeviceFSSuperBlock(DeviceFSType* fs_type, uint32 s_dev) :
-    Superblock(fs_type, s_dev)
+    RamFSSuperblock(fs_type, s_dev)
 {
-  // create the root folder
-  Inode *root_inode = createInode(I_DIR);
-  s_root_ = new Dentry(root_inode);
-  assert(root_inode->mknod(s_root_) == 0);
 }
 
 DeviceFSSuperBlock::~DeviceFSSuperBlock()
 {
-  assert(dirty_inodes_.empty() == true);
-
-  releaseAllOpenFiles();
-
-  deleteAllInodes();
 }
 
 void DeviceFSSuperBlock::addDevice(Inode* device_inode, const char* node_name)
 {
   // Devices are mounted at the devicefs root (s_root_)
+  device_inode->setSuperBlock(this);
+
   Dentry* fdntr = new Dentry(device_inode, s_root_, node_name);
 
-  device_inode->mknod(fdntr);
-  device_inode->setSuperBlock(this);
+  assert(device_inode->mknod(fdntr) == 0);
   all_inodes_.push_back(device_inode);
-}
-
-Inode* DeviceFSSuperBlock::createInode(uint32 type)
-{
-    auto inode = new RamFSInode(this, type);
-    assert(inode);
-
-    all_inodes_.push_back(inode);
-    return inode;
 }
 
 DeviceFSSuperBlock* DeviceFSSuperBlock::getInstance()

--- a/common/source/fs/devicefs/DeviceFSSuperblock.cpp
+++ b/common/source/fs/devicefs/DeviceFSSuperblock.cpp
@@ -16,19 +16,13 @@ const char DeviceFSSuperBlock::DEVICE_ROOT_NAME[] = "dev";
 
 DeviceFSSuperBlock* DeviceFSSuperBlock::instance_ = 0;
 
-DeviceFSSuperBlock::DeviceFSSuperBlock(Dentry* s_root, uint32 s_dev) :
-    Superblock(s_root, s_dev)
+DeviceFSSuperBlock::DeviceFSSuperBlock(uint32 s_dev) :
+    Superblock(s_dev)
 {
   // create the root folder
   Inode *root_inode = createInode(I_DIR);
-  Dentry *root_dentry = new Dentry(root_inode);
-  assert(root_inode->mknod(root_dentry) == 0);
-  s_root_ = root_dentry;
-
-  // mount the superblock over s_root (when used as root file system) or over given mount point
-  mounted_over_ = s_root ?
-      s_root :     // MOUNT
-      root_dentry; // ROOT
+  s_root_ = new Dentry(root_inode);
+  assert(root_inode->mknod(s_root_) == 0);
 }
 
 DeviceFSSuperBlock::~DeviceFSSuperBlock()

--- a/common/source/fs/devicefs/DeviceFSSuperblock.cpp
+++ b/common/source/fs/devicefs/DeviceFSSuperblock.cpp
@@ -1,5 +1,6 @@
 #include "fs/devicefs/DeviceFSSuperblock.h"
 #include "fs/ramfs/RamFSInode.h"
+#include "DeviceFSType.h"
 #include "fs/Dentry.h"
 #include "fs/Inode.h"
 #include "fs/File.h"
@@ -9,6 +10,8 @@
 
 #include "Console.h"
 
+class DeviceFSType;
+
 extern Console* main_console;
 
 const char DeviceFSSuperBlock::ROOT_NAME[] = "/";
@@ -16,8 +19,8 @@ const char DeviceFSSuperBlock::DEVICE_ROOT_NAME[] = "dev";
 
 DeviceFSSuperBlock* DeviceFSSuperBlock::instance_ = 0;
 
-DeviceFSSuperBlock::DeviceFSSuperBlock(uint32 s_dev) :
-    Superblock(s_dev)
+DeviceFSSuperBlock::DeviceFSSuperBlock(DeviceFSType* fs_type, uint32 s_dev) :
+    Superblock(fs_type, s_dev)
 {
   // create the root folder
   Inode *root_inode = createInode(I_DIR);
@@ -100,4 +103,11 @@ int32 DeviceFSSuperBlock::removeFd(Inode* inode, FileDescriptor* fd)
   delete fd;
 
   return tmp;
+}
+
+DeviceFSSuperBlock* DeviceFSSuperBlock::getInstance()
+{
+    if (!instance_)
+        instance_ = new DeviceFSSuperBlock(DeviceFSType::getInstance(), 0);
+    return instance_;
 }

--- a/common/source/fs/devicefs/DeviceFSSuperblock.cpp
+++ b/common/source/fs/devicefs/DeviceFSSuperblock.cpp
@@ -32,19 +32,9 @@ DeviceFSSuperBlock::~DeviceFSSuperBlock()
 {
   assert(dirty_inodes_.empty() == true);
 
-  for (FileDescriptor* fd : s_files_)
-  {
-    delete fd->getFile();
-    delete fd;
-  }
-  s_files_.clear();
+  releaseAllOpenFiles();
 
-  for (Inode* inode : all_inodes_)
-  {
-    delete inode->getDentry();
-    delete inode;
-  }
-  all_inodes_.clear();
+  deleteAllInodes();
 }
 
 void DeviceFSSuperBlock::addDevice(Inode* device_inode, const char* node_name)
@@ -64,45 +54,6 @@ Inode* DeviceFSSuperBlock::createInode(uint32 type)
 
     all_inodes_.push_back(inode);
     return inode;
-}
-
-int32 DeviceFSSuperBlock::createFd(Inode* inode, uint32 flag)
-{
-  assert(inode);
-
-  File* file = inode->open(flag);
-  FileDescriptor* fd = new FileDescriptor(file);
-  s_files_.push_back(fd);
-  FileDescriptor::add(fd);
-
-  if (ustl::find(used_inodes_, inode) == used_inodes_.end())
-  {
-    used_inodes_.push_back(inode);
-  }
-
-  return (fd->getFd());
-}
-
-
-int32 DeviceFSSuperBlock::removeFd(Inode* inode, FileDescriptor* fd)
-{
-  assert(inode);
-  assert(fd);
-
-  s_files_.remove(fd);
-  FileDescriptor::remove(fd);
-
-  File* file = fd->getFile();
-  int32 tmp = inode->release(file);
-
-  debug(RAMFS, "remove the fd num: %d\n", fd->getFd());
-  if (inode->getNumOpenedFile() == 0)
-  {
-    used_inodes_.remove(inode);
-  }
-  delete fd;
-
-  return tmp;
 }
 
 DeviceFSSuperBlock* DeviceFSSuperBlock::getInstance()

--- a/common/source/fs/devicefs/DeviceFSSuperblock.cpp
+++ b/common/source/fs/devicefs/DeviceFSSuperblock.cpp
@@ -91,7 +91,7 @@ int32 DeviceFSSuperBlock::createFd(Inode* inode, uint32 flag)
 {
   assert(inode);
 
-  File* file = inode->link(flag);
+  File* file = inode->open(flag);
   FileDescriptor* fd = new FileDescriptor(file);
   s_files_.push_back(fd);
   FileDescriptor::add(fd);
@@ -114,7 +114,7 @@ int32 DeviceFSSuperBlock::removeFd(Inode* inode, FileDescriptor* fd)
   FileDescriptor::remove(fd);
 
   File* file = fd->getFile();
-  int32 tmp = inode->unlink(file);
+  int32 tmp = inode->release(file);
 
   debug(RAMFS, "remove the fd num: %d\n", fd->getFd());
   if (inode->getNumOpenedFile() == 0)

--- a/common/source/fs/devicefs/DeviceFSType.cpp
+++ b/common/source/fs/devicefs/DeviceFSType.cpp
@@ -4,8 +4,9 @@
 DeviceFSType* DeviceFSType::instance_ = nullptr;
 
 DeviceFSType::DeviceFSType() :
-    FileSystemType("devicefs")
+    RamFSType()
 {
+    fs_name_ = "devicefs";
 }
 
 DeviceFSType::~DeviceFSType()

--- a/common/source/fs/devicefs/DeviceFSType.cpp
+++ b/common/source/fs/devicefs/DeviceFSType.cpp
@@ -15,7 +15,7 @@ Superblock *DeviceFSType::readSuper(Superblock *superblock, void*) const
   return superblock;
 }
 
-Superblock *DeviceFSType::createSuper(Dentry __attribute__((unused)) *root, uint32 __attribute__((unused)) s_dev) const
+Superblock *DeviceFSType::createSuper(uint32 __attribute__((unused)) s_dev) const
 {
   Superblock *super = DeviceFSSuperBlock::getInstance();
   return super;

--- a/common/source/fs/devicefs/DeviceFSType.cpp
+++ b/common/source/fs/devicefs/DeviceFSType.cpp
@@ -1,6 +1,8 @@
 #include "fs/devicefs/DeviceFSType.h"
 #include "fs/devicefs/DeviceFSSuperblock.h"
 
+DeviceFSType* DeviceFSType::instance_ = nullptr;
+
 DeviceFSType::DeviceFSType() :
     FileSystemType("devicefs")
 {
@@ -10,13 +12,20 @@ DeviceFSType::~DeviceFSType()
 {
 }
 
-Superblock *DeviceFSType::readSuper(Superblock *superblock, void*) const
+Superblock* DeviceFSType::readSuper(Superblock *superblock, void*) const
 {
   return superblock;
 }
 
-Superblock *DeviceFSType::createSuper(uint32 __attribute__((unused)) s_dev) const
+Superblock* DeviceFSType::createSuper(uint32 __attribute__((unused)) s_dev)
 {
   Superblock *super = DeviceFSSuperBlock::getInstance();
   return super;
+}
+
+DeviceFSType* DeviceFSType::getInstance()
+{
+    if (!instance_)
+        instance_ = new DeviceFSType();
+    return instance_;
 }

--- a/common/source/fs/minixfs/MinixFSInode.cpp
+++ b/common/source/fs/minixfs/MinixFSInode.cpp
@@ -425,17 +425,16 @@ void MinixFSInode::loadChildren()
         name[MAX_NAME_LENGTH] = 0;
 
         debug(M_INODE, "loadChildren: dentry name: %s\n", name);
-        Dentry *new_dentry = new Dentry(name);
-        i_dentry_->setChild(new_dentry);
-        new_dentry->setParent(i_dentry_);
+        Dentry *new_dentry = new Dentry(inode, i_dentry_, name);
         if (!is_already_loaded)
         {
           ((MinixFSInode *) inode)->i_dentry_ = new_dentry;
           ((MinixFSSuperblock *) superblock_)->all_inodes_add_inode(inode);
         }
         else
-          ((MinixFSInode *) inode)->other_dentries_.push_back(new_dentry);
-        new_dentry->setInode(inode);
+        {
+            ((MinixFSInode *) inode)->other_dentries_.push_back(new_dentry);
+        }
       }
     }
   }

--- a/common/source/fs/minixfs/MinixFSInode.cpp
+++ b/common/source/fs/minixfs/MinixFSInode.cpp
@@ -262,7 +262,7 @@ void MinixFSInode::writeDentry(uint32 dest_i_num, uint32 src_i_num, const char* 
 
 }
 
-File* MinixFSInode::link(uint32 flag)
+File* MinixFSInode::open(uint32 flag)
 {
   debug(M_INODE, "link: flag: %d\n", flag);
   File* file = (File*) (new MinixFSFile(this, i_dentry_, flag));
@@ -271,7 +271,7 @@ File* MinixFSInode::link(uint32 flag)
   return file;
 }
 
-int32 MinixFSInode::unlink(File* file)
+int32 MinixFSInode::release(File* file)
 {
   debug(M_INODE, "unlink\n");
   i_files_.remove(file);

--- a/common/source/fs/minixfs/MinixFSInode.cpp
+++ b/common/source/fs/minixfs/MinixFSInode.cpp
@@ -264,17 +264,19 @@ void MinixFSInode::writeDentry(uint32 dest_i_num, uint32 src_i_num, const char* 
 
 File* MinixFSInode::open(uint32 flag)
 {
-  debug(M_INODE, "link: flag: %d\n", flag);
+  debug(M_INODE, "Open file, flag: %x\n", flag);
   File* file = (File*) (new MinixFSFile(this, i_dentry_, flag));
   i_files_.push_back(file);
+  getSuperblock()->fileOpened(file);
   //++i_nlink_;
   return file;
 }
 
 int32 MinixFSInode::release(File* file)
 {
-  debug(M_INODE, "unlink\n");
+  debug(M_INODE, "Release open file\n");
   i_files_.remove(file);
+  getSuperblock()->fileReleased(file);
   delete file;
   //--i_nlink_;
   return 0;

--- a/common/source/fs/minixfs/MinixFSInode.cpp
+++ b/common/source/fs/minixfs/MinixFSInode.cpp
@@ -8,12 +8,12 @@
 #include "Dentry.h"
 
 MinixFSInode::MinixFSInode(Superblock *super_block, uint32 inode_type) :
-    Inode(super_block, inode_type), i_zones_(0), i_num_(0), children_loaded_(false)
+    Inode(super_block, inode_type),
+    i_zones_(0),
+    i_num_(0),
+    children_loaded_(false)
 {
   debug(M_INODE, "Simple Constructor\n");
-  i_size_ = 0;
-  i_nlink_ = 0;
-  i_dentry_ = 0;
 }
 
 MinixFSInode::MinixFSInode(Superblock *super_block, uint16 i_mode, uint32 i_size, uint16 i_nlinks, uint32* i_zones,
@@ -23,7 +23,6 @@ MinixFSInode::MinixFSInode(Superblock *super_block, uint16 i_mode, uint32 i_size
 {
   i_size_ = i_size;
   i_nlink_ = i_nlinks;
-  i_dentry_ = 0;
   i_state_ = I_UNUSED;
   if (i_mode & 0x8000)
   {
@@ -35,12 +34,12 @@ MinixFSInode::MinixFSInode(Superblock *super_block, uint16 i_mode, uint32 i_size
   }
   else
   {
-    kprintfd("i_mode = %x\n", i_mode);
+    debug(M_INODE, "i_mode = %x\n", i_mode);
     assert(false);
   }
   // (hard/sym link/...) not handled!
 
-  debug(M_INODE, "Constructor: size: %d\tnlink: %d\tnum zones: %d\tmode: %x\n", i_size_, i_nlink_,
+  debug(M_INODE, "Constructor: size: %d\tnlink: %d\tnum zones: %d\tmode: %x\n", i_size_, i_nlink_.load(),
         i_zones_->getNumZones(), i_mode);
 }
 
@@ -48,12 +47,6 @@ MinixFSInode::~MinixFSInode()
 {
   debug(M_INODE, "Destructor\n");
   delete i_zones_;
-
-  while (!other_dentries_.empty())
-  {
-    delete other_dentries_.front();
-    other_dentries_.pop_front();
-  }
 }
 
 int32 MinixFSInode::readData(uint32 offset, uint32 size, char *buffer)
@@ -154,69 +147,39 @@ int32 MinixFSInode::writeData(uint32 offset, uint32 size, const char *buffer)
 
 int32 MinixFSInode::mknod(Dentry *dentry)
 {
-  //debug(M_INODE, "mknod: dentry: %d, i_type_: %d\n",dentry,i_type_);
-  if (dentry == 0)
-  {
-    // ERROR_DNE
-    return -1;
-  }
+  Inode::mknod(dentry);
+  debug(M_INODE, "mknod: dentry: %p, i_type_: %x\n", dentry, i_type_);
 
-  if (i_type_ == I_DIR || i_type_ == I_FILE)
-  {
-    // ERROR_IC
-    return -1;
-  }
-
-  ((MinixFSInode *) dentry->getParent()->getInode())->writeDentry(0, i_num_, i_dentry_->getName());
-  i_dentry_ = dentry;
-  dentry->setInode(this);
-  return 0;
-}
-
-int32 MinixFSInode::mkdir(Dentry *dentry)
-{
-  debug(M_INODE, "mkdir: dentry: %p, i_type_: %d\n", dentry, i_type_);
-  if (dentry == 0)
-  {
-    // ERROR_DNE
-    return -1;
-  }
-
-  if (i_type_ != I_DIR)
-  {
-    // ERROR_IC
-    return -1;
-  }
-  i_dentry_ = dentry;
-  dentry->setInode(this);
-
-  ((MinixFSInode *) dentry->getParent()->getInode())->writeDentry(0, i_num_, i_dentry_->getName());
-  i_nlink_++;
-  writeDentry(0, i_num_, ".");
-  i_nlink_++;
-  writeDentry(0, ((MinixFSInode *) dentry->getParent()->getInode())->i_num_, "..");
-  ((MinixFSInode *) dentry->getParent()->getInode())->i_nlink_++;
+  ((MinixFSInode *) dentry->getParent()->getInode())->writeDentry(0, i_num_, dentry->getName());
   return 0;
 }
 
 int32 MinixFSInode::mkfile(Dentry *dentry)
 {
-  debug(M_INODE, "mkfile: dentry: %p, i_type_: %d\n", dentry, i_type_);
-  if (dentry == 0)
-  {
-    // ERROR_DNE
-    return -1;
-  }
+  Inode::mkfile(dentry);
+  debug(M_INODE, "mkfile: dentry: %p (%s)\n", dentry, dentry->getName());
 
-  if (i_type_ != I_FILE)
-  {
-    // ERROR_IC
-    return -1;
-  }
-  i_dentry_ = dentry;
-  ((MinixFSInode *) dentry->getParent()->getInode())->writeDentry(0, i_num_, i_dentry_->getName());
-  i_dentry_->setInode(this);
-  i_nlink_++;
+  ((MinixFSInode *) dentry->getParent()->getInode())->writeDentry(0, i_num_, dentry->getName());
+  return 0;
+}
+
+int32 MinixFSInode::mkdir(Dentry *dentry)
+{
+  Inode::mkdir(dentry);
+  debug(M_INODE, "mkdir: dentry: %p (%s)\n", dentry, dentry->getName());
+
+  MinixFSInode* parent_inode = ((MinixFSInode *) dentry->getParent()->getInode());
+  assert(parent_inode->getType() == I_DIR);
+
+  parent_inode->writeDentry(0, i_num_, dentry->getName());
+  // link count already increased once in Inode::mkdir(dentry);
+
+  writeDentry(0, i_num_, ".");
+  incLinkCount();
+
+  writeDentry(0, parent_inode->i_num_, "..");
+  parent_inode->incLinkCount();
+
   return 0;
 }
 
@@ -237,6 +200,7 @@ int32 MinixFSInode::findDentry(uint32 i_num)
       }
     }
   }
+  debug(M_INODE, "findDentry: i_num: %d not found\n", i_num);
   return -1;
 }
 
@@ -262,34 +226,52 @@ void MinixFSInode::writeDentry(uint32 dest_i_num, uint32 src_i_num, const char* 
 
 }
 
-File* MinixFSInode::open(uint32 flag)
+File* MinixFSInode::open(Dentry* dentry, uint32 flag)
 {
   debug(M_INODE, "Open file, flag: %x\n", flag);
-  File* file = (File*) (new MinixFSFile(this, i_dentry_, flag));
+  assert(ustl::find(i_dentrys_.begin(), i_dentrys_.end(), dentry) != i_dentrys_.end());
+  File* file = (File*) (new MinixFSFile(this, dentry, flag));
   i_files_.push_back(file);
   getSuperblock()->fileOpened(file);
-  //++i_nlink_;
   return file;
 }
 
-int32 MinixFSInode::release(File* file)
+
+int32 MinixFSInode::link(Dentry* dentry)
 {
-  debug(M_INODE, "Release open file\n");
-  i_files_.remove(file);
-  getSuperblock()->fileReleased(file);
-  delete file;
-  //--i_nlink_;
-  return 0;
+    int32 link_status = Inode::link(dentry);
+    if(link_status)
+    {
+        return link_status;
+    }
+
+    ((MinixFSInode *) dentry->getParent()->getInode())->writeDentry(0, i_num_, dentry->getName());
+
+    return 0;
 }
 
-int32 MinixFSInode::rmdir()
+int32 MinixFSInode::unlink(Dentry* dentry)
 {
-  debug(M_INODE, "rmdir\n");
-  if (i_type_ != I_DIR)
-    return -1;
+    int32 unlink_status = Inode::unlink(dentry);
+    if(unlink_status)
+    {
+        return unlink_status;
+    }
 
-  Dentry* dentry = i_dentry_;
-  Dentry* parent_dentry = dentry->getParent();
+    ((MinixFSInode *) dentry->getParent()->getInode())->writeDentry(i_num_, 0, "");
+
+    return 0;
+}
+
+int32 MinixFSInode::rmdir(Dentry* dentry)
+{
+  assert(dentry && (dentry->getInode() == this));
+  assert(dentry->getParent() && (dentry->getParent()->getInode()));
+  assert(getType() == I_DIR);
+
+  debug(M_INODE, "rmdir %s for inode %p\n", dentry->getName(), this);
+
+  MinixFSInode* parent_inode = static_cast<MinixFSInode*>(dentry->getParent()->getInode());
 
   //the "." and ".." dentries will be deleted in some inode-dtor
   //("." in this inodes-dtor, ".." in the parent-dentry-inodes-dtor)
@@ -299,64 +281,35 @@ int32 MinixFSInode::rmdir()
     {
       //if directory contains other entries than "." or ".."
       //-> directory not empty
+      debug(M_INODE, "Error: Cannot remove non-empty directory\n");
       return -1;
     }
   }
 
-  parent_dentry->childRemove(dentry);
-  char ch = '\0';
+  writeDentry(i_num_, 0, ""); //this was the "."-entry
+  decLinkCount();
 
-  writeDentry(i_num_, 0, &ch); //this was the "."-entry
-  i_nlink_--;
+  writeDentry(parent_inode->i_num_, 0, ""); //this was ".."
+  parent_inode->decLinkCount();
 
-  writeDentry(((MinixFSInode *) parent_dentry->getInode())->i_num_, 0, &ch); //this was ".."
-  ((MinixFSInode *) parent_dentry->getInode())->i_nlink_--;
+  parent_inode->writeDentry(i_num_, 0, "");
+  decLinkCount();
 
-  ((MinixFSInode *) parent_dentry->getInode())->writeDentry(i_num_, 0, &ch);
-  i_nlink_--;
+  assert(i_nlink_ == 0);
 
-  dentry->releaseInode();
-  delete dentry;
-  i_dentry_ = 0;
-  i_nlink_ = 0;
-  return INODE_DEAD;
-}
-
-int32 MinixFSInode::rm()
-{
-  if (i_files_.size() != 0)
-  {
-    debug(M_INODE, "the file is opened.\n");
-    return -1;
-  }
-
-  Dentry* dentry = i_dentry_;
-  if (dentry->emptyChild())
-  {
-    i_type_ = INODE_DEAD;
-    Dentry* parent_dentry = dentry->getParent();
-    parent_dentry->childRemove(dentry);
-    char ch = '\0';
-    ((MinixFSInode *) parent_dentry->getInode())->writeDentry(((MinixFSInode *) dentry->getInode())->i_num_, 0, &ch);
-    i_nlink_--;
-
-    dentry->releaseInode();
-    delete dentry;
-    i_dentry_ = 0;
-    debug(M_INODE, "rm: deleted\n");
-    return INODE_DEAD;
-  }
-  else
-  {
-    // ERROR_DEC
-    return -1;
-  }
+  return 0;
 }
 
 Dentry* MinixFSInode::lookup(const char* name)
 {
+  if(i_type_ != I_DIR)
+  {
+    return nullptr;
+  }
 
-  debug(M_INODE, "lookup: name: %s this->i_dentry_->getName(): %s \n", name, this->i_dentry_->getName());
+  assert(i_dentrys_.size() >= 1);
+
+  debug(M_INODE, "lookup: name: %s this->i_dentry_->getName(): %s \n", name, i_dentrys_.front()->getName());
   if (name == 0)
   {
     // ERROR_DNE
@@ -365,28 +318,20 @@ Dentry* MinixFSInode::lookup(const char* name)
 
   Dentry* dentry_update = 0;
 
-  if (i_type_ == I_DIR)
+  dentry_update = i_dentrys_.front()->checkName(name);
+  if (dentry_update == 0)
   {
-    dentry_update = i_dentry_->checkName(name);
-    if (dentry_update == 0)
-    {
-      // ERROR_NNE
-      return (Dentry*) 0;
-    }
-    else
-    {
-      debug(M_INODE, "lookup: dentry_update->getName(): %s\n", dentry_update->getName());
-      if (((MinixFSInode *) dentry_update->getInode())->i_type_ == I_DIR)
-      {
-        ((MinixFSInode *) dentry_update->getInode())->loadChildren();
-      }
-      return dentry_update;
-    }
+    // ERROR_NNE
+    return (Dentry*) 0;
   }
   else
   {
-    // ERROR_IC
-    return (Dentry*) 0;
+    debug(M_INODE, "lookup: dentry_update->getName(): %s\n", dentry_update->getName());
+    if (((MinixFSInode *) dentry_update->getInode())->i_type_ == I_DIR)
+    {
+      ((MinixFSInode *) dentry_update->getInode())->loadChildren();
+    }
+    return dentry_update;
   }
 }
 
@@ -409,7 +354,7 @@ void MinixFSInode::loadChildren()
         debug(M_INODE, "loadChildren: loading child %d\n", inode_index);
         bool is_already_loaded = false;
 
-        Inode* inode = ((MinixFSSuperblock *) superblock_)->getInode(inode_index, is_already_loaded);
+        MinixFSInode* inode = ((MinixFSSuperblock *) superblock_)->getInode(inode_index, is_already_loaded);
 
         if (!inode)
         {
@@ -427,15 +372,13 @@ void MinixFSInode::loadChildren()
         name[MAX_NAME_LENGTH] = 0;
 
         debug(M_INODE, "loadChildren: dentry name: %s\n", name);
-        Dentry *new_dentry = new Dentry(inode, i_dentry_, name);
+        assert(i_dentrys_.size() >= 1);
+        Dentry *new_dentry = new Dentry(inode, i_dentrys_.front(), name);
+        inode->i_dentrys_.push_back(new_dentry);
+
         if (!is_already_loaded)
         {
-          ((MinixFSInode *) inode)->i_dentry_ = new_dentry;
           ((MinixFSSuperblock *) superblock_)->all_inodes_add_inode(inode);
-        }
-        else
-        {
-            ((MinixFSInode *) inode)->other_dentries_.push_back(new_dentry);
         }
       }
     }

--- a/common/source/fs/minixfs/MinixFSSuperblock.cpp
+++ b/common/source/fs/minixfs/MinixFSSuperblock.cpp
@@ -309,7 +309,7 @@ int32 MinixFSSuperblock::createFd(Inode* inode, uint32 flag)
 {
   assert(inode);
 
-  File* file = inode->link(flag);
+  File* file = inode->open(flag);
   FileDescriptor* fd = new FileDescriptor(file);
   s_files_.push_back(fd);
   FileDescriptor::add(fd);
@@ -331,7 +331,7 @@ int32 MinixFSSuperblock::removeFd(Inode* inode, FileDescriptor* fd)
   FileDescriptor::remove(fd);
 
   File* file = fd->getFile();
-  int32 tmp = inode->unlink(file);
+  int32 tmp = inode->release(file);
 
   debug(M_SB, "remove the fd num: %d\n", fd->getFd());
   if (inode->getNumOpenedFile() == 0)

--- a/common/source/fs/minixfs/MinixFSSuperblock.cpp
+++ b/common/source/fs/minixfs/MinixFSSuperblock.cpp
@@ -71,7 +71,7 @@ void MinixFSSuperblock::readHeader()
 void MinixFSSuperblock::initInodes()
 {
   MinixFSInode *root_inode = getInode(1);
-  Dentry *root_dentry = new Dentry(ROOT_NAME);
+  Dentry *root_dentry = new Dentry(root_inode);
   if (s_root_)
   {
     //root_dentry->setMountPoint(s_root_);
@@ -85,9 +85,7 @@ void MinixFSSuperblock::initInodes()
     s_root_ = root_dentry;
 
   }
-  root_dentry->setParent(root_dentry);
   root_inode->i_dentry_ = root_dentry;
-  root_dentry->setInode(root_inode);
 
   all_inodes_add_inode(root_inode);
   //read children from disc
@@ -185,7 +183,7 @@ MinixFSSuperblock::~MinixFSSuperblock()
   debug(M_SB, "~MinixSuperblock finished\n");
 }
 
-Inode* MinixFSSuperblock::createInode(Dentry* dentry, uint32 type)
+Inode* MinixFSSuperblock::createInode(uint32 type)
 {
   uint16 mode = 0x01ff;
   if (type == I_FILE)
@@ -203,19 +201,6 @@ Inode* MinixFSSuperblock::createInode(Dentry* dentry, uint32 type)
   all_inodes_add_inode(inode);
   debug(M_SB, "createInode> calling write Inode to Disc\n");
   writeInode(inode);
-  debug(M_SB, "createInode> returned from write Inode to Disc\n");
-  if (type == I_DIR)
-  {
-    debug(M_SB, "createInode> mkdir\n");
-    int32 inode_init = inode->mkdir(dentry);
-    assert(inode_init == 0);
-  }
-  else if (type == I_FILE)
-  {
-    debug(M_SB, "createInode> mkfile\n");
-    int32 inode_init = inode->mkfile(dentry);
-    assert(inode_init == 0);
-  }
   debug(M_SB, "createInode> finished\n");
   return inode;
 }

--- a/common/source/fs/minixfs/MinixFSSuperblock.cpp
+++ b/common/source/fs/minixfs/MinixFSSuperblock.cpp
@@ -271,7 +271,7 @@ void MinixFSSuperblock::all_inodes_remove_inode(Inode* inode)
   all_inodes_set_.erase(((MinixFSInode*) inode)->i_num_);
 }
 
-void MinixFSSuperblock::delete_inode(Inode* inode)
+void MinixFSSuperblock::deleteInode(Inode* inode)
 {
   Dentry* dentry = inode->getDentry();
   assert(dentry == 0);

--- a/common/source/fs/minixfs/MinixFSSuperblock.cpp
+++ b/common/source/fs/minixfs/MinixFSSuperblock.cpp
@@ -1,4 +1,5 @@
 #include "FileDescriptor.h"
+#include "MinixFSType.h"
 #include "MinixFSSuperblock.h"
 #include "MinixFSInode.h"
 #include "MinixFSFile.h"
@@ -15,10 +16,9 @@
 
 #define ROOT_NAME "/"
 
-MinixFSSuperblock::MinixFSSuperblock(size_t s_dev, uint64 offset) :
-    Superblock(s_dev), superblock_(this)
+MinixFSSuperblock::MinixFSSuperblock(MinixFSType* fs_type, size_t s_dev, uint64 offset) :
+    Superblock(fs_type, s_dev), superblock_(this), offset_(offset)
 {
-  offset_ = offset;
   //read Superblock data from disc
   readHeader();
   debug(M_SB, "s_num_inodes_ : %d\ns_zones_ : %d\ns_num_inode_bm_blocks_ : %d\ns_num_zone_bm_blocks_ : %d\n"

--- a/common/source/fs/minixfs/MinixFSSuperblock.cpp
+++ b/common/source/fs/minixfs/MinixFSSuperblock.cpp
@@ -15,8 +15,8 @@
 
 #define ROOT_NAME "/"
 
-MinixFSSuperblock::MinixFSSuperblock(Dentry* s_root, size_t s_dev, uint64 offset) :
-    Superblock(s_root, s_dev), superblock_(this)
+MinixFSSuperblock::MinixFSSuperblock(size_t s_dev, uint64 offset) :
+    Superblock(s_dev), superblock_(this)
 {
   offset_ = offset;
   //read Superblock data from disc
@@ -71,26 +71,12 @@ void MinixFSSuperblock::readHeader()
 void MinixFSSuperblock::initInodes()
 {
   MinixFSInode *root_inode = getInode(1);
-  Dentry *root_dentry = new Dentry(root_inode);
-  if (s_root_)
-  {
-    //root_dentry->setMountPoint(s_root_);
-    s_root_->setMountPoint(root_dentry);
-    mounted_over_ = s_root_; // MOUNT
-    s_root_ = root_dentry;
-  }
-  else
-  {
-    mounted_over_ = root_dentry; // ROOT
-    s_root_ = root_dentry;
-
-  }
-  root_inode->i_dentry_ = root_dentry;
+  s_root_ = new Dentry(root_inode);
+  root_inode->i_dentry_ = s_root_;
 
   all_inodes_add_inode(root_inode);
   //read children from disc
   root_inode->loadChildren();
-
 }
 
 MinixFSInode* MinixFSSuperblock::getInode(uint16 i_num, bool &is_already_loaded)

--- a/common/source/fs/minixfs/MinixFSType.cpp
+++ b/common/source/fs/minixfs/MinixFSType.cpp
@@ -5,6 +5,7 @@
 
 MinixFSType::MinixFSType() : FileSystemType("minixfs")
 {
+    fs_flags_ |= FS_REQUIRES_DEV;
 }
 
 

--- a/common/source/fs/minixfs/MinixFSType.cpp
+++ b/common/source/fs/minixfs/MinixFSType.cpp
@@ -20,12 +20,12 @@ Superblock *MinixFSType::readSuper(Superblock *superblock, void*) const
 }
 
 
-Superblock *MinixFSType::createSuper(uint32 s_dev) const
+Superblock *MinixFSType::createSuper(uint32 s_dev)
 {
   if (s_dev == (uint32) -1)
     return 0;
 
   BDManager::getInstance()->getDeviceByNumber(s_dev)->setBlockSize(BLOCK_SIZE);
-  Superblock *super = new MinixFSSuperblock(s_dev, 0);
+  Superblock *super = new MinixFSSuperblock(this, s_dev, 0);
   return super;
 }

--- a/common/source/fs/minixfs/MinixFSType.cpp
+++ b/common/source/fs/minixfs/MinixFSType.cpp
@@ -20,12 +20,12 @@ Superblock *MinixFSType::readSuper(Superblock *superblock, void*) const
 }
 
 
-Superblock *MinixFSType::createSuper(Dentry *root, uint32 s_dev) const
+Superblock *MinixFSType::createSuper(uint32 s_dev) const
 {
   if (s_dev == (uint32) -1)
     return 0;
 
   BDManager::getInstance()->getDeviceByNumber(s_dev)->setBlockSize(BLOCK_SIZE);
-  Superblock *super = new MinixFSSuperblock(root, s_dev, 0);
+  Superblock *super = new MinixFSSuperblock(s_dev, 0);
   return super;
 }

--- a/common/source/fs/ramfs/RamFSInode.cpp
+++ b/common/source/fs/ramfs/RamFSInode.cpp
@@ -4,6 +4,7 @@
 #include "fs/ramfs/RamFSSuperblock.h"
 #include "fs/ramfs/RamFSFile.h"
 #include "fs/Dentry.h"
+#include "FileSystemType.h"
 
 #include "console/kprintf.h"
 
@@ -109,14 +110,18 @@ int32 RamFSInode::create(Dentry *dentry)
 
 File* RamFSInode::open(uint32 flag)
 {
+  debug(INODE, "%s Inode: Open file\n", getSuperblock()->getFSType()->getFSName());
   File* file = (File*) (new RamFSFile(this, i_dentry_, flag));
   i_files_.push_back(file);
+  getSuperblock()->fileOpened(file);
   return file;
 }
 
 int32 RamFSInode::release(File* file)
 {
+  debug(INODE, "%s Inode: Release file\n", getSuperblock()->getFSType()->getFSName());
   i_files_.remove(file);
+  getSuperblock()->fileReleased(file);
   delete file;
   return 0;
 }
@@ -146,6 +151,7 @@ int32 RamFSInode::rmdir()
 
 int32 RamFSInode::rm()
 {
+  debug(RAMFS, "Removing RamFs Inode %p\n", this);
   if (i_files_.size() != 0)
   {
     kprintfd("RamFSInode::ERROR: the file is opened.\n");

--- a/common/source/fs/ramfs/RamFSInode.cpp
+++ b/common/source/fs/ramfs/RamFSInode.cpp
@@ -107,14 +107,14 @@ int32 RamFSInode::create(Dentry *dentry)
   return (mkdir(dentry));
 }
 
-File* RamFSInode::link(uint32 flag)
+File* RamFSInode::open(uint32 flag)
 {
   File* file = (File*) (new RamFSFile(this, i_dentry_, flag));
   i_files_.push_back(file);
   return file;
 }
 
-int32 RamFSInode::unlink(File* file)
+int32 RamFSInode::release(File* file)
 {
   i_files_.remove(file);
   delete file;

--- a/common/source/fs/ramfs/RamFSInode.cpp
+++ b/common/source/fs/ramfs/RamFSInode.cpp
@@ -80,7 +80,7 @@ int32 RamFSInode::mknod(Dentry *dentry)
 
 int32 RamFSInode::mkdir(Dentry *dentry)
 {
-  return (mkdir(dentry));
+  return mknod(dentry);
 }
 
 int32 RamFSInode::mkfile(Dentry *dentry)

--- a/common/source/fs/ramfs/RamFSSuperblock.cpp
+++ b/common/source/fs/ramfs/RamFSSuperblock.cpp
@@ -15,7 +15,7 @@ RamFSSuperblock::RamFSSuperblock(RamFSType* fs_type, uint32 s_dev) :
 {
   Inode *root_inode = createInode(I_DIR);
   s_root_ = new Dentry(root_inode);
-  assert(root_inode->mknod(s_root_) == 0);
+  assert(root_inode->mkdir(s_root_) == 0);
 }
 
 RamFSSuperblock::~RamFSSuperblock()
@@ -60,4 +60,5 @@ void RamFSSuperblock::writeInode(Inode* inode)
 void RamFSSuperblock::deleteInode(Inode* inode)
 {
   all_inodes_.remove(inode);
+  delete inode;
 }

--- a/common/source/fs/ramfs/RamFSSuperblock.cpp
+++ b/common/source/fs/ramfs/RamFSSuperblock.cpp
@@ -12,27 +12,15 @@
 RamFSSuperblock::RamFSSuperblock(Dentry* s_root, uint32 s_dev) :
     Superblock(s_root, s_dev)
 {
-  Inode *root_inode = (Inode*) (new RamFSInode(this, I_DIR));
+  Inode *root_inode = createInode(I_DIR);
   Dentry *root_dentry = new Dentry(root_inode);
-
-  if (s_root)
-  {
-    // MOUNT
-    mounted_over_ = s_root;
-  }
-  else
-  {
-    // ROOT
-    mounted_over_ = root_dentry;
-  }
+  assert(root_inode->mknod(root_dentry) == 0);
   s_root_ = root_dentry;
 
-  // create the inode for the root_dentry
-  int32 root_init = root_inode->mknod(root_dentry);
-  assert(root_init == 0);
-
-  // add the root_inode in the list
-  all_inodes_.push_back(root_inode);
+  // mount the superblock over s_root (when used as root file system) or over given mount point
+  mounted_over_ = s_root ?
+      s_root :     // MOUNT
+      root_dentry; // ROOT
 }
 
 RamFSSuperblock::~RamFSSuperblock()

--- a/common/source/fs/ramfs/RamFSSuperblock.cpp
+++ b/common/source/fs/ramfs/RamFSSuperblock.cpp
@@ -9,18 +9,12 @@
 #include "console/debug.h"
 #define ROOT_NAME "/"
 
-RamFSSuperblock::RamFSSuperblock(Dentry* s_root, uint32 s_dev) :
-    Superblock(s_root, s_dev)
+RamFSSuperblock::RamFSSuperblock(uint32 s_dev) :
+    Superblock(s_dev)
 {
   Inode *root_inode = createInode(I_DIR);
-  Dentry *root_dentry = new Dentry(root_inode);
-  assert(root_inode->mknod(root_dentry) == 0);
-  s_root_ = root_dentry;
-
-  // mount the superblock over s_root (when used as root file system) or over given mount point
-  mounted_over_ = s_root ?
-      s_root :     // MOUNT
-      root_dentry; // ROOT
+  s_root_ = new Dentry(root_inode);
+  assert(root_inode->mknod(s_root_) == 0);
 }
 
 RamFSSuperblock::~RamFSSuperblock()

--- a/common/source/fs/ramfs/RamFSSuperblock.cpp
+++ b/common/source/fs/ramfs/RamFSSuperblock.cpp
@@ -2,6 +2,7 @@
 #include "fs/ramfs/RamFSSuperblock.h"
 #include "fs/ramfs/RamFSInode.h"
 #include "fs/ramfs/RamFSFile.h"
+#include "fs/ramfs/RamFSType.h"
 #include "fs/Dentry.h"
 #include "assert.h"
 
@@ -9,8 +10,8 @@
 #include "console/debug.h"
 #define ROOT_NAME "/"
 
-RamFSSuperblock::RamFSSuperblock(uint32 s_dev) :
-    Superblock(s_dev)
+RamFSSuperblock::RamFSSuperblock(RamFSType* fs_type, uint32 s_dev) :
+    Superblock(fs_type, s_dev)
 {
   Inode *root_inode = createInode(I_DIR);
   s_root_ = new Dentry(root_inode);

--- a/common/source/fs/ramfs/RamFSSuperblock.cpp
+++ b/common/source/fs/ramfs/RamFSSuperblock.cpp
@@ -12,7 +12,8 @@
 RamFSSuperblock::RamFSSuperblock(Dentry* s_root, uint32 s_dev) :
     Superblock(s_root, s_dev)
 {
-  Dentry *root_dentry = new Dentry(ROOT_NAME);
+  Inode *root_inode = (Inode*) (new RamFSInode(this, I_DIR));
+  Dentry *root_dentry = new Dentry(root_inode);
 
   if (s_root)
   {
@@ -27,7 +28,6 @@ RamFSSuperblock::RamFSSuperblock(Dentry* s_root, uint32 s_dev) :
   s_root_ = root_dentry;
 
   // create the inode for the root_dentry
-  Inode *root_inode = (Inode*) (new RamFSInode(this, I_DIR));
   int32 root_init = root_inode->mknod(root_dentry);
   assert(root_init == 0);
 
@@ -54,25 +54,13 @@ RamFSSuperblock::~RamFSSuperblock()
   all_inodes_.clear();
 }
 
-Inode* RamFSSuperblock::createInode(Dentry* dentry, uint32 type)
+Inode* RamFSSuperblock::createInode(uint32 type)
 {
-  Inode *inode = (Inode*) (new RamFSInode(this, type));
-  assert(inode);
-  if (type == I_DIR)
-  {
-    debug(RAMFS, "createInode: I_DIR\n");
-    int32 inode_init = inode->mknod(dentry);
-    assert(inode_init == 0);
-  }
-  else if (type == I_FILE)
-  {
-    debug(RAMFS, "createInode: I_FILE\n");
-    int32 inode_init = inode->mkfile(dentry);
-    assert(inode_init == 0);
-  }
+    debug(RAMFS, "createInode, type: %x\n", type);
+    auto inode = new RamFSInode(this, type);
 
-  all_inodes_.push_back(inode);
-  return inode;
+    all_inodes_.push_back(inode);
+    return inode;
 }
 
 int32 RamFSSuperblock::readInode(Inode* inode)

--- a/common/source/fs/ramfs/RamFSSuperblock.cpp
+++ b/common/source/fs/ramfs/RamFSSuperblock.cpp
@@ -93,7 +93,7 @@ int32 RamFSSuperblock::createFd(Inode* inode, uint32 flag)
 {
   assert(inode);
 
-  File* file = inode->link(flag);
+  File* file = inode->open(flag);
   FileDescriptor* fd = new FileDescriptor(file);
   s_files_.push_back(fd);
   FileDescriptor::add(fd);
@@ -115,7 +115,7 @@ int32 RamFSSuperblock::removeFd(Inode* inode, FileDescriptor* fd)
   FileDescriptor::remove(fd);
 
   File* file = fd->getFile();
-  int32 tmp = inode->unlink(file);
+  int32 tmp = inode->release(file);
 
   debug(RAMFS, "remove the fd num: %d\n", fd->getFd());
   if (inode->getNumOpenedFile() == 0)

--- a/common/source/fs/ramfs/RamFSSuperblock.cpp
+++ b/common/source/fs/ramfs/RamFSSuperblock.cpp
@@ -67,7 +67,7 @@ void RamFSSuperblock::writeInode(Inode* inode)
   }
 }
 
-void RamFSSuperblock::delete_inode(Inode* inode)
+void RamFSSuperblock::deleteInode(Inode* inode)
 {
   all_inodes_.remove(inode);
 }

--- a/common/source/fs/ramfs/RamFSSuperblock.cpp
+++ b/common/source/fs/ramfs/RamFSSuperblock.cpp
@@ -22,19 +22,9 @@ RamFSSuperblock::~RamFSSuperblock()
 {
   assert(dirty_inodes_.empty() == true);
 
-  for (FileDescriptor* fd : s_files_)
-  {
-    delete fd->getFile();
-    delete fd;
-  }
-  s_files_.clear();
+  releaseAllOpenFiles();
 
-  for (Inode* inode : all_inodes_)
-  {
-    delete inode->getDentry();
-    delete inode;
-  }
-  all_inodes_.clear();
+  deleteAllInodes();
 }
 
 Inode* RamFSSuperblock::createInode(uint32 type)
@@ -70,42 +60,4 @@ void RamFSSuperblock::writeInode(Inode* inode)
 void RamFSSuperblock::deleteInode(Inode* inode)
 {
   all_inodes_.remove(inode);
-}
-
-int32 RamFSSuperblock::createFd(Inode* inode, uint32 flag)
-{
-  assert(inode);
-
-  File* file = inode->open(flag);
-  FileDescriptor* fd = new FileDescriptor(file);
-  s_files_.push_back(fd);
-  FileDescriptor::add(fd);
-
-  if (ustl::find(used_inodes_, inode) == used_inodes_.end())
-  {
-    used_inodes_.push_back(inode);
-  }
-
-  return (fd->getFd());
-}
-
-int32 RamFSSuperblock::removeFd(Inode* inode, FileDescriptor* fd)
-{
-  assert(inode);
-  assert(fd);
-
-  s_files_.remove(fd);
-  FileDescriptor::remove(fd);
-
-  File* file = fd->getFile();
-  int32 tmp = inode->release(file);
-
-  debug(RAMFS, "remove the fd num: %d\n", fd->getFd());
-  if (inode->getNumOpenedFile() == 0)
-  {
-    used_inodes_.remove(inode);
-  }
-  delete fd;
-
-  return tmp;
 }

--- a/common/source/fs/ramfs/RamFSType.cpp
+++ b/common/source/fs/ramfs/RamFSType.cpp
@@ -11,14 +11,14 @@ RamFSType::~RamFSType()
 {}
 
 
-Superblock *RamFSType::readSuper ( Superblock *superblock, void* ) const
+Superblock *RamFSType::readSuper(Superblock *superblock, void*) const
 {
   return superblock;
 }
 
 
-Superblock *RamFSType::createSuper ( Dentry *root, uint32 s_dev ) const
+Superblock *RamFSType::createSuper (uint32 s_dev) const
 {
-  Superblock *super = new RamFSSuperblock ( root, s_dev );
+  Superblock *super = new RamFSSuperblock(s_dev);
   return super;
 }

--- a/common/source/fs/ramfs/RamFSType.cpp
+++ b/common/source/fs/ramfs/RamFSType.cpp
@@ -17,8 +17,8 @@ Superblock *RamFSType::readSuper(Superblock *superblock, void*) const
 }
 
 
-Superblock *RamFSType::createSuper (uint32 s_dev) const
+Superblock *RamFSType::createSuper (uint32 s_dev)
 {
-  Superblock *super = new RamFSSuperblock(s_dev);
+  Superblock *super = new RamFSSuperblock(this, s_dev);
   return super;
 }

--- a/common/source/kernel/ProcessRegistry.cpp
+++ b/common/source/kernel/ProcessRegistry.cpp
@@ -32,10 +32,16 @@ void ProcessRegistry::Run()
 
   debug(PROCESS_REG, "mounting userprog-partition \n");
 
-  VfsSyscall::mkdir("/usr", 0);
   debug(PROCESS_REG, "mkdir /usr\n");
-  VfsSyscall::mount("idea1", "/usr", "minixfs", 0);
+  VfsSyscall::mkdir("/usr", 0);
   debug(PROCESS_REG, "mount idea1\n");
+  VfsSyscall::mount("idea1", "/usr", "minixfs", 0);
+
+  debug(PROCESS_REG, "mkdir /dev\n");
+  VfsSyscall::mkdir("/dev", 0);
+  debug(PROCESS_REG, "mount devicefs\n");
+  VfsSyscall::mount(NULL, "/dev", "devicefs", 0);
+
 
   KernelMemoryManager::instance()->startTracing();
 

--- a/common/source/kernel/ProcessRegistry.cpp
+++ b/common/source/kernel/ProcessRegistry.cpp
@@ -4,6 +4,7 @@
 #include "UserProcess.h"
 #include "kprintf.h"
 #include "VfsSyscall.h"
+#include "VirtualFileSystem.h"
 
 
 ProcessRegistry* ProcessRegistry::instance_ = 0;
@@ -60,6 +61,8 @@ void ProcessRegistry::Run()
   debug(PROCESS_REG, "unmounting userprog-partition because all processes terminated \n");
 
   VfsSyscall::umount("/usr", 0);
+  VfsSyscall::umount("/dev", 0);
+  vfs.rootUmount();
 
   Scheduler::instance()->printStackTraces();
 

--- a/common/source/kernel/ProcessRegistry.cpp
+++ b/common/source/kernel/ProcessRegistry.cpp
@@ -33,14 +33,14 @@ void ProcessRegistry::Run()
   debug(PROCESS_REG, "mounting userprog-partition \n");
 
   debug(PROCESS_REG, "mkdir /usr\n");
-  VfsSyscall::mkdir("/usr", 0);
+  assert( !VfsSyscall::mkdir("/usr", 0) );
   debug(PROCESS_REG, "mount idea1\n");
-  VfsSyscall::mount("idea1", "/usr", "minixfs", 0);
+  assert( !VfsSyscall::mount("idea1", "/usr", "minixfs", 0) );
 
   debug(PROCESS_REG, "mkdir /dev\n");
-  VfsSyscall::mkdir("/dev", 0);
+  assert( !VfsSyscall::mkdir("/dev", 0) );
   debug(PROCESS_REG, "mount devicefs\n");
-  VfsSyscall::mount(NULL, "/dev", "devicefs", 0);
+  assert( !VfsSyscall::mount(NULL, "/dev", "devicefs", 0) );
 
 
   KernelMemoryManager::instance()->startTracing();

--- a/common/source/kernel/main.cpp
+++ b/common/source/kernel/main.cpp
@@ -26,6 +26,7 @@
 #include "RamFSType.h"
 #include "MinixFSType.h"
 #include "VirtualFileSystem.h"
+#include "FileDescriptor.h"
 #include "TextConsole.h"
 #include "FrameBufferConsole.h"
 #include "Terminal.h"
@@ -92,6 +93,9 @@ extern "C" void startup()
   default_working_dir = vfs.rootMount("ramfs", 0);
   assert(default_working_dir);
 
+  // initialise global and static objects
+  new (&global_fd_list) FileDescriptorList();
+
   debug(MAIN, "Block Device creation\n");
   BDManager::getInstance()->doDeviceDetection();
   debug(MAIN, "Block Device done\n");
@@ -101,18 +105,14 @@ extern "C" void startup()
     debug(MAIN, "Detected Device: %s :: %d\n", bdvd->getName(), bdvd->getDeviceNumber());
   }
 
-  // initialise global and static objects
-  extern ustl::list<FileDescriptor*> global_fd;
-  new (&global_fd) ustl::list<FileDescriptor*>();
-  extern Mutex global_fd_lock;
-  new (&global_fd_lock) Mutex("global_fd_lock");
 
   debug(MAIN, "make a deep copy of FsWorkingDir\n");
   main_console->setWorkingDirInfo(new FileSystemInfo(*default_working_dir));
   debug(MAIN, "main_console->setWorkingDirInfo done\n");
 
   ustl::coutclass::init();
-  debug(MAIN, "default_working_dir root name: %s\t pwd name: %s\n", default_working_dir->getRoot().dentry_->getName(),
+  debug(MAIN, "default_working_dir root name: %s\t pwd name: %s\n",
+        default_working_dir->getRoot().dentry_->getName(),
         default_working_dir->getPwd().dentry_->getName());
   if (main_console->getWorkingDirInfo())
   {

--- a/common/source/kernel/main.cpp
+++ b/common/source/kernel/main.cpp
@@ -24,6 +24,7 @@
 #include "Dentry.h"
 #include "DeviceFSType.h"
 #include "RamFSType.h"
+#include "MinixFSType.h"
 #include "VirtualFileSystem.h"
 #include "TextConsole.h"
 #include "FrameBufferConsole.h"
@@ -85,8 +86,9 @@ extern "C" void startup()
 
   vfs.initialize();
   debug(MAIN, "Mounting root file system\n");
-  vfs.registerFileSystem(new DeviceFSType());
+  vfs.registerFileSystem(DeviceFSType::getInstance());
   vfs.registerFileSystem(new RamFSType());
+  vfs.registerFileSystem(new MinixFSType());
   default_working_dir = vfs.rootMount("ramfs", 0);
   assert(default_working_dir);
 
@@ -110,8 +112,8 @@ extern "C" void startup()
   debug(MAIN, "main_console->setWorkingDirInfo done\n");
 
   ustl::coutclass::init();
-  debug(MAIN, "default_working_dir root name: %s\t pwd name: %s\n", default_working_dir->getRoot()->getName(),
-        default_working_dir->getPwd()->getName());
+  debug(MAIN, "default_working_dir root name: %s\t pwd name: %s\n", default_working_dir->getRoot().dentry_->getName(),
+        default_working_dir->getPwd().dentry_->getName());
   if (main_console->getWorkingDirInfo())
   {
     delete main_console->getWorkingDirInfo();

--- a/common/source/kernel/main.cpp
+++ b/common/source/kernel/main.cpp
@@ -87,7 +87,7 @@ extern "C" void startup()
   debug(MAIN, "Mounting root file system\n");
   vfs.registerFileSystem(new DeviceFSType());
   vfs.registerFileSystem(new RamFSType());
-  default_working_dir = vfs.root_mount("ramfs", 0);
+  default_working_dir = vfs.rootMount("ramfs", 0);
   assert(default_working_dir);
 
   debug(MAIN, "Block Device creation\n");

--- a/common/source/kernel/main.cpp
+++ b/common/source/kernel/main.cpp
@@ -23,6 +23,7 @@
 #include "FileSystemInfo.h"
 #include "Dentry.h"
 #include "DeviceFSType.h"
+#include "RamFSType.h"
 #include "VirtualFileSystem.h"
 #include "TextConsole.h"
 #include "FrameBufferConsole.h"
@@ -83,10 +84,11 @@ extern "C" void startup()
   ArchCommon::initDebug();
 
   vfs.initialize();
-  debug(MAIN, "Mounting DeviceFS under /dev/\n");
-  DeviceFSType *devfs = new DeviceFSType();
-  vfs.registerFileSystem(devfs);
-  default_working_dir = vfs.root_mount("devicefs", 0);
+  debug(MAIN, "Mounting root file system\n");
+  vfs.registerFileSystem(new DeviceFSType());
+  vfs.registerFileSystem(new RamFSType());
+  default_working_dir = vfs.root_mount("ramfs", 0);
+  assert(default_working_dir);
 
   debug(MAIN, "Block Device creation\n");
   BDManager::getInstance()->doDeviceDetection();

--- a/userspace/tests/shell.c
+++ b/userspace/tests/shell.c
@@ -56,7 +56,10 @@ void handle_command(char* buffer, int buffer_size)
     }
   }
   if (strcmp(command, "ls") == 0)
-    __syscall(sc_pseudols, (size_t) (argsCount > 0 ? args[0] : ""), 0, 0, 0, 0);
+  {
+    __syscall(sc_pseudols, (size_t) (argsCount > 0 ? args[0] : "."), 0, 0, 0, 0);
+  }
+
   else if (buffer[0] == 'h' && buffer[1] == 'e' && buffer[2] == 'l' && buffer[3] == 'p')
   {
     printf(

--- a/utils/add-debug/dwarf/small_vector.hh
+++ b/utils/add-debug/dwarf/small_vector.hh
@@ -138,11 +138,13 @@ public:
 
         reference front()
         {
+                assert(base.size() >= 1);
                 return base[0];
         }
 
         const_reference front() const
         {
+                assert(base.size() >= 1);
                 return base[0];
         }
 

--- a/utils/exe2minixfs/CMakeLists.txt
+++ b/utils/exe2minixfs/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.1.0)
 
 file(GLOB util_exe2minixfs_SOURCES *.cpp
                                    ../../common/source/util/Bitmap.cpp
+                                   ../../common/source/fs/Inode.cpp
                                    ../../common/source/fs/Dentry.cpp
                                    ../../common/source/fs/FileDescriptor.cpp
                                    ../../common/source/fs/FileSystemInfo.cpp

--- a/utils/exe2minixfs/CMakeLists.txt
+++ b/utils/exe2minixfs/CMakeLists.txt
@@ -5,9 +5,11 @@ file(GLOB util_exe2minixfs_SOURCES *.cpp
                                    ../../common/source/fs/Dentry.cpp
                                    ../../common/source/fs/FileDescriptor.cpp
                                    ../../common/source/fs/FileSystemInfo.cpp
+                                   ../../common/source/fs/FileSystemType.cpp
                                    ../../common/source/fs/Superblock.cpp
                                    ../../common/source/fs/File.cpp
                                    ../../common/source/fs/PathWalker.cpp
+                                   ../../common/source/fs/Path.cpp
                                    ../../common/source/fs/VfsMount.cpp
                                    ../../common/source/fs/VfsSyscall.cpp
                                    ../../common/source/fs/minixfs/MinixFSFile.cpp

--- a/utils/exe2minixfs/CMakeLists.txt
+++ b/utils/exe2minixfs/CMakeLists.txt
@@ -28,6 +28,7 @@ target_include_directories(exe2minixfs
     ../../common/include/util
     ../../common/include/fs
     ../../common/include/fs/minixfs
+    ../../common/include/console
 )
 
 target_compile_definitions(exe2minixfs PRIVATE EXE2MINIXFS=1)

--- a/utils/exe2minixfs/MinixFSType.h
+++ b/utils/exe2minixfs/MinixFSType.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "FileSystemType.h"
+#include "assert.h"
+
+class MinixFSType : public FileSystemType
+{
+public:
+    MinixFSType() :
+        FileSystemType("minixfs")
+    {
+
+    }
+
+    virtual ~MinixFSType()
+    {
+
+    }
+
+    virtual Superblock *readSuper(Superblock *, void *) const
+    {
+        assert(0 && "Not implemented in exe2minixfs");
+    }
+
+    virtual Superblock *createSuper(uint32)
+    {
+        assert(0 && "Not implemented in exe2minixfs");
+    }
+};

--- a/utils/exe2minixfs/Mutex.h
+++ b/utils/exe2minixfs/Mutex.h
@@ -1,0 +1,22 @@
+// WARNING: You are looking for a different Mutex.h - this one is just for the exe2minixfs tool!
+#ifdef EXE2MINIXFS
+#pragma once
+
+class Mutex
+{
+public:
+
+  Mutex(const char*){};
+
+  Mutex(Mutex const &) = delete;
+  Mutex &operator=(Mutex const&) = delete;
+
+  bool acquireNonBlocking(pointer = 0){return true;};
+
+  void acquire(pointer = 0){};
+  void release(pointer = 0){};
+
+  bool isFree(){ return true; };
+};
+
+#endif

--- a/utils/exe2minixfs/MutexLock.h
+++ b/utils/exe2minixfs/MutexLock.h
@@ -1,0 +1,17 @@
+// WARNING: You are looking for a different MutexLock.h - this one is just for the exe2minixfs tool!
+
+#ifdef EXE2MINIXFS
+#pragma once
+
+class Mutex;
+
+class MutexLock
+{
+public:
+    MutexLock(Mutex &){};
+    MutexLock(Mutex &, bool){};
+
+    MutexLock(MutexLock const&) = delete;
+    MutexLock &operator=(MutexLock const&) = delete;
+};
+#endif

--- a/utils/exe2minixfs/exe2minixfs.cpp
+++ b/utils/exe2minixfs/exe2minixfs.cpp
@@ -106,9 +106,9 @@ int main(int argc, char *argv[])
     delete[] buf;
   }
 
-  delete minixfs_type;
   delete default_working_dir;
   delete superblock_;
+  delete minixfs_type;
   fclose(image_fd);
 
   return 0;

--- a/utils/exe2minixfs/exe2minixfs.cpp
+++ b/utils/exe2minixfs/exe2minixfs.cpp
@@ -52,10 +52,12 @@ int main(int argc, char *argv[])
     return -1;
   }
 
-  superblock_ = (Superblock*) new MinixFSSuperblock(0, (size_t)image_fd, offset);
+  superblock_ = (Superblock*) new MinixFSSuperblock((size_t)image_fd, offset);
+  Dentry *root = superblock_->getRoot();
+  superblock_->setMountPoint(root);
   Dentry *mount_point = superblock_->getMountPoint();
   mount_point->setMountPoint(mount_point);
-  Dentry *root = superblock_->getRoot();
+
 
   default_working_dir = new FileSystemInfo();
   default_working_dir->setFsRoot(root, &vfs_dummy_);

--- a/utils/exe2minixfs/exe2minixfs.cpp
+++ b/utils/exe2minixfs/exe2minixfs.cpp
@@ -66,8 +66,8 @@ int main(int argc, char *argv[])
 
   default_working_dir = new FileSystemInfo();
   Path root_path(root, &vfs_dummy_);
-  default_working_dir->setFsRoot(root_path);
-  default_working_dir->setFsPwd(root_path);
+  default_working_dir->setRoot(root_path);
+  default_working_dir->setPwd(root_path);
 
   for (int32 i = 2; i <= argc / 2; i++)
   {

--- a/utils/exe2minixfs/types.h
+++ b/utils/exe2minixfs/types.h
@@ -1,9 +1,7 @@
-// WARNING: You are looking for the a different types.h - this one is just for the exe2minixfs tool!
+// WARNING: You are looking for a different types.h - this one is just for the exe2minixfs tool!
 #ifdef EXE2MINIXFS
 #pragma once
 
-#define Mutex const char*
-#define MutexLock __attribute__((unused)) const char*
 #define ArchThreads
 
 #include <stdint.h>

--- a/utils/exe2minixfs/ustl/uatomic.h
+++ b/utils/exe2minixfs/ustl/uatomic.h
@@ -1,0 +1,5 @@
+// WARNING: This is only a dummy header for the exe2minixfs tool!
+#ifdef EXE2MINIXFS
+#pragma once
+#include <atomic>
+#endif


### PR DESCRIPTION
Clean up + simplify file system code + combine and re-use previously duplicated common functionality. Working with and extending the file system code should now be much easier than before.

- Simplify + clean up file lookup (remove unnecessary dupCheck() function and associated semi-global state)
  - Unify path + associated functions into class instead of a loose collection of functions + state variables
- Refactor filesystem mounts
- File system specific inode functions now only have to implement actual file system specific functions instead of also setting up dentries, etc...
- Use ramfs instead of devicefs as root file system
- Use actual class for file descriptor list instead of ad-hoc global functions
- Reverse creation of inode + dentry (inode now created first) to allow for more code reuse
- Rename functions to more closely match what they actually do (link/unlink)
- Fix (previously half-implemented) support for multiple links to a file
  - Consider multiple reference to inodes (dentry links, open files)