### PR TITLE
Fix CI build warning + ARM build

### DIFF
--- a/common/include/fs/Inode.h
+++ b/common/include/fs/Inode.h
@@ -51,12 +51,12 @@ class Inode
     /**
      * the number of Dentry links to this inode.
      */
-    ustl::atomic<uint32> i_nlink_;
+    uint32 i_nlink_;
 
     /**
      * the number of runtime references to this inode (loaded Dentrys, open files, ...)
      */
-    ustl::atomic<uint32> i_refcount_;
+    uint32 i_refcount_;
 
     Superblock *superblock_;
 
@@ -96,6 +96,7 @@ class Inode
 
     uint32 incLinkCount();
     uint32 decLinkCount();
+    uint32 numLinks();
 
     void addDentry(Dentry* dentry);
     void removeDentry(Dentry* dentry);

--- a/common/source/fs/Inode.cpp
+++ b/common/source/fs/Inode.cpp
@@ -18,11 +18,11 @@ Inode::Inode(Superblock *superblock, uint32 inode_type) :
 
 Inode::~Inode()
 {
-    if(i_refcount_ != 0)
+    if(numRefs() != 0)
     {
-        debug(INODE, "~Inode %s %p refcount: %u\n", getSuperblock()->getFSType()->getFSName(), this, i_refcount_.load());
+        debug(INODE, "~Inode %s %p refcount: %u\n", getSuperblock()->getFSType()->getFSName(), this, numRefs());
     }
-    assert(i_refcount_ == 0);
+    assert(numRefs() == 0);
 }
 
 uint32 Inode::incRefCount()
@@ -55,7 +55,12 @@ uint32 Inode::decLinkCount()
 
 uint32 Inode::numRefs()
 {
-    return i_refcount_.load();
+    return i_refcount_;
+}
+
+uint32 Inode::numLinks()
+{
+    return i_nlink_;
 }
 
 

--- a/common/source/fs/PathWalker.cpp
+++ b/common/source/fs/PathWalker.cpp
@@ -83,13 +83,18 @@ int32 PathWalker::pathWalk(const char* pathname, const Path& pwd, const Path& ro
     switch(pathSegmentType(segment))
     {
     case LAST_DOT:
+    {
         debug(PATHWALKER, "pathWalk> follow last dot\n");
         break;
+    }
     case LAST_DOTDOT:
+    {
         debug(PATHWALKER, "pathWalk> follow last dotdot\n");
         out = out.parent(&root);
         break;
+    }
     case LAST_NORM:
+    {
         debug(PATHWALKER, "pathWalk> follow last norm segment: %s\n", segment);
 
         Path child;
@@ -105,6 +110,7 @@ int32 PathWalker::pathWalk(const char* pathname, const Path& pwd, const Path& ro
 
         out = child;
         break;
+    }
     default:
         assert(false);
     }

--- a/common/source/fs/minixfs/MinixFSInode.cpp
+++ b/common/source/fs/minixfs/MinixFSInode.cpp
@@ -39,7 +39,7 @@ MinixFSInode::MinixFSInode(Superblock *super_block, uint16 i_mode, uint32 i_size
   }
   // (hard/sym link/...) not handled!
 
-  debug(M_INODE, "Constructor: size: %d\tnlink: %d\tnum zones: %d\tmode: %x\n", i_size_, i_nlink_.load(),
+  debug(M_INODE, "Constructor: size: %d\tnlink: %d\tnum zones: %d\tmode: %x\n", i_size_, numLinks(),
         i_zones_->getNumZones(), i_mode);
 }
 

--- a/common/source/fs/minixfs/MinixFSSuperblock.cpp
+++ b/common/source/fs/minixfs/MinixFSSuperblock.cpp
@@ -220,7 +220,7 @@ void MinixFSSuperblock::writeInode(Inode* inode)
   readBytes(block, offset, INODE_SIZE, buffer);
   debug(M_SB, "writeInode> read data from disc\n");
   debug(M_SB, "writeInode> the inode: i_type_: %d, i_nlink_: %d, i_size_: %d\n", minix_inode->i_type_,
-        minix_inode->i_nlink_.load(), minix_inode->i_size_);
+        minix_inode->numLinks(), minix_inode->i_size_);
   if (minix_inode->i_type_ == I_FILE)
   {
     debug(M_SB, "writeInode> setting mode to file : %x\n", *(uint16*) buffer | 0x81FF);
@@ -236,11 +236,11 @@ void MinixFSSuperblock::writeInode(Inode* inode)
     // link etc. unhandled
   }
   ((uint32*)buffer)[1+V3_OFFSET] = minix_inode->i_size_;
-  debug(M_SB, "writeInode> write inode %p link count %u\n", inode, minix_inode->i_nlink_.load());
+  debug(M_SB, "writeInode> write inode %p link count %u\n", inode, minix_inode->numLinks());
   if (s_magic_ == MINIX_V3)
-    ((uint16*)buffer)[1] = minix_inode->i_nlink_;
+    ((uint16*)buffer)[1] = minix_inode->numLinks();
   else
-    buffer[13] = minix_inode->i_nlink_;
+    buffer[13] = minix_inode->numLinks();
   debug(M_SB, "writeInode> writing bytes to disc on block %d with offset %d\n", block, offset);
   writeBytes(block, offset, INODE_SIZE, buffer);
   debug(M_SB, "writeInode> flushing zones of inode %p\n", inode);


### PR DESCRIPTION
CI build complains about local variable being visible across case labels. Add blocks to reduce scope of variable.
(Warning didn't show up locally for some reason but does in CI)

\+ make inode refcount non-atomic to fix arm build (ustl::atomic doesn't work properly on arm #257 )