### PR TITLE
update kernel stack placement

### DIFF
--- a/common/include/kernel/Thread.h
+++ b/common/include/kernel/Thread.h
@@ -91,11 +91,11 @@ class Thread
      * @return true if ready for scheduling
      */
     bool schedulable();
-
-
+  
+  
+    uint32 kernel_stack_[2048];
     ArchThreadRegisters* kernel_registers_;
     ArchThreadRegisters* user_registers_;
-    uint32 kernel_stack_[2048];
 
     uint32 switch_to_userspace_;
 


### PR DESCRIPTION
Having the kernel stack below the pointers to the stored registers leads to problems when detecting stack overflows.