### PR TITLE
update BACKTRACE_MAX_FRAMES assert

### DIFF
--- a/common/source/kernel/Thread.cpp
+++ b/common/source/kernel/Thread.cpp
@@ -129,7 +129,7 @@ void Thread::printBacktrace(bool use_stored_registers)
     debug(BACKTRACE, "Kernel debug info not set up, backtrace won't look nice!\n");
   }
 
-  assert(BACKTRACE_MAX_FRAMES < 128);
+  static_assert(BACKTRACE_MAX_FRAMES < 128);
   pointer call_stack[BACKTRACE_MAX_FRAMES];
   size_t count = 0;
 


### PR DESCRIPTION
Having an assert in a function that gets called by assert is probably a bad idea.