### PR TITLE
Only warn on format string errors to account for compiler version differences

### DIFF
--- a/arch/arm/integratorcp/CMakeLists.include
+++ b/arch/arm/integratorcp/CMakeLists.include
@@ -1,6 +1,6 @@
 set(KERNEL_BINARY kernel.x)
 
-set(ARCH_ARM_ICP_KERNEL_CFLAGS -O0 -gstabs2 -Wall -Wextra -Werror -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mapcs -marm -march=armv5te -Wno-strict-aliasing -fshort-wchar ${NOPICFLAG})
+set(ARCH_ARM_ICP_KERNEL_CFLAGS -O0 -gstabs2 -Wall -Wextra -Werror -Wno-error=format -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mapcs -marm -march=armv5te -Wno-strict-aliasing -fshort-wchar ${NOPICFLAG})
 
 set(KERNEL_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -std=gnu++17 -Wno-nonnull-compare -nostdinc++ -fno-rtti ${ARCH_ARM_ICP_KERNEL_CFLAGS})
 set(KERNEL_CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   -std=gnu11 ${ARCH_ARM_ICP_KERNEL_CFLAGS})

--- a/arch/arm/rpi2/CMakeLists.include
+++ b/arch/arm/rpi2/CMakeLists.include
@@ -1,6 +1,6 @@
 set(KERNEL_BINARY kernel.x)
 
-set(ARCH_RPI_KERNEL_CFLAGS -O0 -gstabs2 -Wall -Wextra -Werror -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mapcs -marm -Wno-strict-aliasing -march=armv6 -fshort-wchar ${NOPICFLAG})
+set(ARCH_RPI_KERNEL_CFLAGS -O0 -gstabs2 -Wall -Wextra -Werror -Wno-error=format -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mapcs -marm -Wno-strict-aliasing -march=armv6 -fshort-wchar ${NOPICFLAG})
 
 set(KERNEL_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -std=gnu++17 -Wno-nonnull-compare -nostdinc++ -fno-rtti ${ARCH_RPI_KERNEL_CFLAGS})
 set(KERNEL_CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   -std=gnu11 ${ARCH_RPI_KERNEL_CFLAGS})

--- a/arch/x86/32/CMakeLists.include
+++ b/arch/x86/32/CMakeLists.include
@@ -1,6 +1,6 @@
 set(KERNEL_BINARY kernel.x)
 
-set(ARCH_X86_32_KERNEL_CFLAGS -m32 -O0 -gstabs2 -Wall -Wextra -Werror -Wno-nonnull-compare -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mno-red-zone -mno-mmx -mno-sse2 -mno-sse3 -mno-3dnow ${NOPICFLAG})
+set(ARCH_X86_32_KERNEL_CFLAGS -m32 -O0 -gstabs2 -Wall -Wextra -Werror -Wno-error=format -Wno-nonnull-compare -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mno-red-zone -mno-mmx -mno-sse2 -mno-sse3 -mno-3dnow ${NOPICFLAG})
 
 set(KERNEL_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -std=gnu++17 -nostdinc++ -fno-rtti ${ARCH_X86_32_KERNEL_CFLAGS})
 set(KERNEL_CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   -std=gnu11 ${ARCH_X86_32_KERNEL_CFLAGS})

--- a/arch/x86/32/pae/CMakeLists.include
+++ b/arch/x86/32/pae/CMakeLists.include
@@ -1,6 +1,6 @@
 set(KERNEL_BINARY kernel.x)
 
-set(ARCH_X86_32_PAE_KERNEL_CFLAGS -m32 -O0 -gstabs2 -Wall -Wextra -Werror -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -mno-mmx -mno-sse2 -mno-sse3 ${NOPICFLAG})
+set(ARCH_X86_32_PAE_KERNEL_CFLAGS -m32 -O0 -gstabs2 -Wall -Wextra -Werror -Wno-error=format -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -mno-mmx -mno-sse2 -mno-sse3 ${NOPICFLAG})
 
 set(KERNEL_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -std=gnu++11 -Wno-nonnull-compare -nostdinc++ -fno-rtti ${ARCH_X86_32_PAE_KERNEL_CFLAGS})
 set(KERNEL_CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   -std=gnu11 ${ARCH_X86_32_PAE_KERNEL_CFLAGS})

--- a/arch/x86/64/CMakeLists.include
+++ b/arch/x86/64/CMakeLists.include
@@ -6,7 +6,7 @@ else()
   set(FCF_PROTECTION_FLAG )
 endif()
 
-set(ARCH_X86_64_KERNEL_CFLAGS -m64 -O0 -gdwarf-2 -Wall -Wextra -Werror -Wno-nonnull-compare -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mcmodel=kernel -mno-red-zone -mgeneral-regs-only -mno-mmx -mno-sse2 -mno-sse3 -mno-3dnow ${FCF_PROTECTION_FLAG} ${NOPICFLAG})
+set(ARCH_X86_64_KERNEL_CFLAGS -m64 -O0 -gdwarf-2 -Wall -Wextra -Werror -Wno-error=format -Wno-nonnull-compare -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mcmodel=kernel -mno-red-zone -mgeneral-regs-only -mno-mmx -mno-sse2 -mno-sse3 -mno-3dnow ${FCF_PROTECTION_FLAG} ${NOPICFLAG})
 
 set(KERNEL_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -std=gnu++17 -nostdinc++ -fno-rtti ${ARCH_X86_64_KERNEL_CFLAGS})
 set(KERNEL_CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   -std=gnu11 ${ARCH_X86_64_KERNEL_CFLAGS})


### PR DESCRIPTION
Some GCC versions (e.g. 11.1.0) complain about wrong format string arguments when printing values of bit fields:
`debug(SYSCALL, "PPN is: %zd\n", m.pt[m.pti].page_ppn);`

`warning: format ‘%zd’ expects argument of type ‘signed size_t’, but argument 2 has type ‘int’ [-Wformat=]`
Older compilers allow this.

A quick google search didn't come up with a way to make newer compilers behave like older ones in this regard, so this pull request changes this error to a warning to allow people with newer compilers to at least compile the code with warnings.




