### PR TITLE
Add condition variable assert

### DIFF
--- a/common/source/kernel/Condition.cpp
+++ b/common/source/kernel/Condition.cpp
@@ -46,6 +46,10 @@ void Condition::wait(bool re_acquire_mutex, pointer called_by)
           "This may lower the performance of the system, and cause undetectable deadlocks!\n",
           currentThread->getName(), currentThread, getName(), this);
     printHoldingList(currentThread);
+
+    // This might not be a problem, but it is slow and in a lot of cases WILL lead to hard to find deadlocks.
+    // If you want to remove this assert talk to your tutor FIRST!
+    assert(currentThread->holding_lock_list_->hasNextOnHoldingList() && "thread is holding locks while waiting on a condition variable");
   }
   lockWaitersList();
   last_accessed_at_ = called_by;

--- a/common/source/kernel/Condition.cpp
+++ b/common/source/kernel/Condition.cpp
@@ -47,9 +47,11 @@ void Condition::wait(bool re_acquire_mutex, pointer called_by)
           currentThread->getName(), currentThread, getName(), this);
     printHoldingList(currentThread);
 
-    // This might not be a problem, but it is slow and WILL lead to hard-to-find deadlocks in many cases.
+
+    // Holding locks that are not released by the CV when waiting on it is strongly discouraged.
+    // It might not be a problem, but it is slow and WILL lead to hard-to-find deadlocks in most cases.
     // If you want to remove this assert, talk to your tutor FIRST!
-    assert(!currentThread->holding_lock_list_->hasNextOnHoldingList() && "thread is holding locks while waiting on a condition variable");
+    assert(!currentThread->holding_lock_list_->hasNextOnHoldingList() && "thread is holding unrelated locks while waiting on a condition variable");
   }
   lockWaitersList();
   last_accessed_at_ = called_by;

--- a/common/source/kernel/Condition.cpp
+++ b/common/source/kernel/Condition.cpp
@@ -47,8 +47,8 @@ void Condition::wait(bool re_acquire_mutex, pointer called_by)
           currentThread->getName(), currentThread, getName(), this);
     printHoldingList(currentThread);
 
-    // This might not be a problem, but it is slow and in a lot of cases WILL lead to hard to find deadlocks.
-    // If you want to remove this assert talk to your tutor FIRST!
+    // This might not be a problem, but it is slow and WILL lead to hard-to-find deadlocks in many cases.
+    // If you want to remove this assert, talk to your tutor FIRST!
     assert(!currentThread->holding_lock_list_->hasNextOnHoldingList() && "thread is holding locks while waiting on a condition variable");
   }
   lockWaitersList();

--- a/common/source/kernel/Condition.cpp
+++ b/common/source/kernel/Condition.cpp
@@ -49,7 +49,7 @@ void Condition::wait(bool re_acquire_mutex, pointer called_by)
 
     // This might not be a problem, but it is slow and in a lot of cases WILL lead to hard to find deadlocks.
     // If you want to remove this assert talk to your tutor FIRST!
-    assert(currentThread->holding_lock_list_->hasNextOnHoldingList() && "thread is holding locks while waiting on a condition variable");
+    assert(!currentThread->holding_lock_list_->hasNextOnHoldingList() && "thread is holding locks while waiting on a condition variable");
   }
   lockWaitersList();
   last_accessed_at_ = called_by;

--- a/common/source/mm/PageFaultHandler.cpp
+++ b/common/source/mm/PageFaultHandler.cpp
@@ -56,8 +56,8 @@ inline void PageFaultHandler::handlePageFault(size_t address, bool user,
         writing ? "writing" : "reading",
         fetch ? "instruction" : "    operand",
         switch_to_us);
-  //Uncomment the line below if you want to have detailed information about the thread registers.
-  //ArchThreads::printThreadRegisters(currentThread, false);
+
+  ArchThreads::printThreadRegisters(currentThread, false);
 
   if (checkPageFaultIsValid(address, user, present, switch_to_us))
   {


### PR DESCRIPTION
Many students do not see CVs as something that could produce deadlocks. While holding locks when waiting on a CV is not a bug in itself in a lot of cases, it is either unnecessary or extremely slow. I am also done with people completely ignoring the warning even when it eventually leads to a deadlock (which happens in most cases where this warning is printed).

This PR also uncomments the register dump line in the PF handler per default since it does not hurt and is, in general, very useful.