### PR TITLE
Use actual gdb breakpoint at startup instead of pseudo software breakpoint

### DIFF
--- a/arch/x86/64/CMakeLists.include
+++ b/arch/x86/64/CMakeLists.include
@@ -68,8 +68,8 @@ add_custom_target(qemu
 
 # qemugdb: Run qemu in debugging mode
 add_custom_target(qemugdb
-	COMMAND	${QEMU_BIN} ${QEMU_FLAGS_COMMON} -s
-	COMMENT "Executing `gdb ${QEMU_BIN} ${QEMU_FLAGS_COMMON_STR} -s on localhost:1234`"
+	COMMAND	${QEMU_BIN} ${QEMU_FLAGS_COMMON} -s -S
+	COMMENT "Executing `gdb ${QEMU_BIN} ${QEMU_FLAGS_COMMON_STR} -s -S on localhost:1234`"
 	WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
 	COMMAND reset -I
 	)

--- a/common/source/kernel/main.cpp
+++ b/common/source/kernel/main.cpp
@@ -45,13 +45,6 @@ extern "C" void removeBootTimeIdentMapping();
 
 extern "C" void startup()
 {
-#ifdef DEBUG
-  //software breakpoint for debugging
-  writeLine2Bochs("Wait for GDB!\n");
-  bool cont = false;
-  while(!cont);
-#endif
-
   writeLine2Bochs("Removing Boot Time Ident Mapping...\n");
   removeBootTimeIdentMapping();
   system_state = BOOTING;

--- a/utils/gdbinit
+++ b/utils/gdbinit
@@ -8,18 +8,11 @@ end
 
 define continue_on_pagefault
 	handle SIGSEGV nostop noprint nopass
-	echo Now continueing on every pagefault\n
+	echo Now continuing on every pagefault\n
 end
 document continue_on_pagefault
 	Tells GDB to ignore pagefaults
 end 
-
-# Special Macro definition that GDB calls on every break
-define hook-stop
-	echo \n
-	echo 'c' to continue execution\n
-	echo 's' to step\n
-end
 
 set architecture i386:x86-64
 
@@ -31,5 +24,5 @@ echo \n\n
 echo You can now set trace and breakpoints.\n
 echo Enter 'continue' (or 'c') when you're done.\n
 
-set var cont=true
 break sweb_assert
+break startup


### PR DESCRIPTION
\+ Start qemu x86_64 in paused mode to allow debugger to connect (matching all other architectures)