### PR TITLE
explicitly disabling stack clash protection

### DIFF
--- a/arch/arm/integratorcp/CMakeLists.userspace
+++ b/arch/arm/integratorcp/CMakeLists.userspace
@@ -5,5 +5,5 @@ find_program(CMAKE_C_COMPILER arm-none-eabi-gcc)
 
 set(ARCH_APPEND_LD_ARGUMENTS -Wl,-no-whole-archive -Wl,-lgcc)
 
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gstabs2 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Werror=implicit-function-declaration)
+set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gstabs2 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Werror=implicit-function-declaration -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)

--- a/arch/arm/rpi2/CMakeLists.userspace
+++ b/arch/arm/rpi2/CMakeLists.userspace
@@ -5,5 +5,5 @@ find_program(CMAKE_C_COMPILER arm-none-eabi-gcc)
 
 set(ARCH_APPEND_LD_ARGUMENTS -Wl,-no-whole-archive -Wl,-lgcc)
 
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -g -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Werror=implicit-function-declaration)
+set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -g -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Werror=implicit-function-declaration -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)

--- a/arch/armv8/rpi3/CMakeLists.userspace
+++ b/arch/armv8/rpi3/CMakeLists.userspace
@@ -5,5 +5,5 @@ find_program(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
 
 set(ARCH_APPEND_LD_ARGUMENTS -Wl,-no-whole-archive -Wl,-lgcc)
 
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror  -std=gnu11 -g -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Werror=implicit-function-declaration)
+set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror  -std=gnu11 -g -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Werror=implicit-function-declaration -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)

--- a/arch/x86/32/CMakeLists.userspace
+++ b/arch/x86/32/CMakeLists.userspace
@@ -1,2 +1,2 @@
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gstabs2 -fno-omit-frame-pointer -O0 -m32 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Werror=implicit-function-declaration)
+set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gstabs2 -fno-omit-frame-pointer -O0 -m32 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Werror=implicit-function-declaration -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)

--- a/arch/x86/32/pae/CMakeLists.userspace
+++ b/arch/x86/32/pae/CMakeLists.userspace
@@ -1,2 +1,2 @@
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gstabs2 -fno-omit-frame-pointer -O0 -m32 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Werror=implicit-function-declaration)
+set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gstabs2 -fno-omit-frame-pointer -O0 -m32 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Werror=implicit-function-declaration -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)

--- a/arch/x86/64/CMakeLists.userspace
+++ b/arch/x86/64/CMakeLists.userspace
@@ -1,2 +1,2 @@
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -g -O0 -m64 -static -nostdinc -fno-builtin -nostdlib -nodefaultlibs -fno-stack-protector -fno-common -Werror=implicit-function-declaration)
+set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -g -O0 -m64 -static -nostdinc -fno-builtin -nostdlib -nodefaultlibs -fno-stack-protector -fno-common -Werror=implicit-function-declaration -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)


### PR DESCRIPTION
On some gcc versions on Ubuntu the stack clash protection is enabled per default leading to confusion when testing growing stacks and swapping with large stack arrays in SWEB. As found by Mario Bischof the compiler flag -fno-stack-clash-protection explicitly disables that feature. In this pull request, it is added to the compilation flags of all supported architectures.