### PR TITLE
Fix userspace debug info for gcc >= 11

### DIFF
--- a/arch/x86/64/CMakeLists.userspace
+++ b/arch/x86/64/CMakeLists.userspace
@@ -1,2 +1,2 @@
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -g -O0 -m64 -static -nostdinc -fno-builtin -nostdlib -nodefaultlibs -fno-stack-protector -fno-common -Werror=implicit-function-declaration -fno-stack-clash-protection)
+set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -g -gdwarf-4 -O0 -m64 -static -nostdinc -fno-builtin -nostdlib -nodefaultlibs -fno-stack-protector -fno-common -Werror=implicit-function-declaration -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)


### PR DESCRIPTION
gcc 11 uses dwarf5 debug info by default. The libelfin library used for the `add-dbg` utility can only handle up to dwarf4.