### PR TITLE
Bug Fix: pseudols Arbitrary Read Vulnerability

### DIFF
--- a/common/source/kernel/Syscall.cpp
+++ b/common/source/kernel/Syscall.cpp
@@ -58,8 +58,10 @@ size_t Syscall::syscallException(size_t syscall_number, size_t arg1, size_t arg2
 
 void Syscall::pseudols(const char *pathname, char *buffer, size_t size)
 {
-  if(buffer && ((size_t)buffer >= USER_BREAK || (size_t)buffer + size > USER_BREAK))
+  if (buffer && ((size_t)buffer >= USER_BREAK || (size_t)buffer + size > USER_BREAK))
     return;
+  if (pathname >= USER_BREAK)
+	  return;
   VfsSyscall::readdir(pathname, buffer, size);
 }
 


### PR DESCRIPTION
The `pseudols` syscall does not validate the `pathname` pointer, thus allowing arbitrary kernel read by calling the `pseudols` syscall with an attacker-controller address. This PR tackles this issue by validating the pointer resides below the `USER_BREAK` address.

Note: This patch might still leave some exploitable conditions since on some architectures (like 32-bit x86), `pathname` might contain a usermode address that's right behind the beginning of the kernel upper half (on x86_64 this cannot happen due to the address canonization requirement). This is a much less severe issue, and since it requires a more massive patch to completely remediate, I'll let you think if you want to tackle this scenario as well in another PR.