### PR TITLE
fix tss size and io base

### DIFF
--- a/arch/x86/32/common/source/SegmentUtils.cpp
+++ b/arch/x86/32/common/source/SegmentUtils.cpp
@@ -43,7 +43,7 @@ static void setSegmentDescriptor(uint32 index, uint32 base, uint32 limit, uint8 
     gdt[index].baseH  = (uint8)((base >> 24U) & 0xFF);
     gdt[index].limitL = (uint16)(limit & 0xFFFF);
     gdt[index].limitH = (uint8) (((limit >> 16U) & 0xF));
-    gdt[index].typeH  = 0xC; // 4kb + 32bit
+    gdt[index].typeH  = tss ? 0 : 0xC; // 4kb + 32bit
     gdt[index].typeL  = (tss ? 0x89 : 0x92) | (dpl << 5) | (code ? 0x8 : 0); // present bit + memory expands upwards + code
 }
 
@@ -57,6 +57,7 @@ void SegmentUtils::initialise()
   g_tss = (TSS*)new uint8[sizeof(TSS)]; // new uint8[sizeof(TSS)];
   memset((void*)g_tss, 0, sizeof(TSS));
   g_tss->ss0 = KERNEL_SS;
+  g_tss->iobase = -1;
   setSegmentDescriptor(6, (uint32)g_tss, sizeof(TSS)-1, 0, 0, 1);
   // we have to reload our segment stuff
   gdt_ptr.limit = sizeof(gdt) - 1;

--- a/arch/x86/64/source/boot.32.C
+++ b/arch/x86/64/source/boot.32.C
@@ -48,7 +48,9 @@ typedef struct
     uint32 reserved_2;
     uint32 ist0_l;
     uint32 ist0_h;
-    uint32 reserved_3[15];
+    uint32 reserved_3[14];
+    uint16 reserved_4;
+    uint16 iobp;
 }__attribute__((__packed__)) TSS;
 
 TSS g_tss;
@@ -86,7 +88,7 @@ static void setSegmentDescriptor(uint32 index, uint32 baseH, uint32 baseL, uint3
   gdt_p[index].baseH = baseH;
   gdt_p[index].limitL = (uint16) (limit & 0xFFFF);
   gdt_p[index].limitH = (uint8) (((limit >> 16U) & 0xF));
-  gdt_p[index].typeH = code ? 0xA : 0xC; // 4kb + 64bit
+  gdt_p[index].typeH = tss ? 0 : (code ? 0xA : 0xC); // 4kb + 64bit
   gdt_p[index].typeL = (tss ? 0x89 : 0x92) | ((dpl & 0x3) << 5) | (code ? 0x8 : 0); // present bit + memory expands upwards + code
 }
 
@@ -137,6 +139,7 @@ extern "C" void entry()
   g_tss_p->ist0_l = (uint32) TRUNCATE(boot_stack) | 0x80004000;
   g_tss_p->rsp0_h = -1U;
   g_tss_p->rsp0_l = (uint32) TRUNCATE(boot_stack) | 0x80004000;
+  g_tss_p->iobp = -1;
 
   PRINT("Setup Segments...\n");
   setSegmentDescriptor(1, 0, 0, 0xFFFFFFFF, 0, 1, 0);


### PR DESCRIPTION
Changed segment granularity for the TSS from page size to byte granularity.
The I/O map base address in the TSS was set to 0 which made it possible for ring 3 code to execute in/out instructions with most ports (including PIC, disk i/o, qemu debug, ...).