### PR TITLE
user backtrace fix

### DIFF
--- a/arch/x86/64/source/ArchMemory.cpp
+++ b/arch/x86/64/source/ArchMemory.cpp
@@ -160,6 +160,12 @@ ArchMemory::~ArchMemory()
 
 pointer ArchMemory::checkAddressValid(uint64 vaddress_to_check)
 {
+  if (vaddress_to_check >= USER_BREAK && vaddress_to_check < KERNEL_START)
+  {
+    debug(A_MEMORY, "checkAddressValid %zx non-canonical -> false\n", vaddress_to_check);
+    return 0;
+  }
+
   ArchMemoryMapping m = resolveMapping(page_map_level_4_, vaddress_to_check / PAGE_SIZE);
   if (m.page != 0)
   {

--- a/arch/x86/64/source/arch_backtrace.cpp
+++ b/arch/x86/64/source/arch_backtrace.cpp
@@ -62,9 +62,8 @@ int backtrace(pointer *call_stack, int size, Thread *thread, bool use_stored_reg
 
 int backtrace_user(pointer *call_stack, int size, Thread *thread, bool /*use_stored_registers*/)
 {
-  if (!call_stack || !size || !thread->user_registers_)
+  if (!call_stack || !size || !thread->user_registers_ || (thread->user_registers_->rbp % sizeof(pointer)))
     return 0;
-
   void *rbp = (void*)thread->user_registers_->rbp;
   StackFrame *CurrentFrame = (StackFrame*)rbp;
   StackFrame *CurrentFrameI = (StackFrame*)thread->loader_->arch_memory_.checkAddressValid((pointer)rbp);
@@ -85,10 +84,15 @@ int backtrace_user(pointer *call_stack, int size, Thread *thread, bool /*use_sto
       ADDRESS_BETWEEN(StackEnd, StartAddress, EndAddress) &&
       ADDRESS_BETWEEN(StackStart, StartAddress, EndAddress) &&
       CurrentFrameI &&
-      ADDRESS_BETWEEN(CurrentFrameI->return_address, StartAddress, EndAddress))
+      ADDRESS_BETWEEN(CurrentFrameI->return_address, StartAddress, EndAddress) &&
+      thread->loader_->arch_memory_.checkAddressValid((pointer)&CurrentFrameI->return_address))
   {
     call_stack[i++] = (pointer)CurrentFrameI->return_address;
     CurrentFrame = CurrentFrameI->previous_frame;
+
+    if (((pointer)CurrentFrame) % sizeof(pointer))
+      break;
+
     CurrentFrameI = (StackFrame*)thread->loader_->arch_memory_.checkAddressValid((pointer)CurrentFrameI->previous_frame);
   }
 


### PR DESCRIPTION
checkAddressValid panics when given a non-canonical address due to the new assert in resolveMapping.
A user could trigger this by crashing with a non-canonical address in rbp.
Add an extra check in checkAddressValid since it should never assert.

An incorrectly aligned user-space stack could make the user backtrace function read from an incorrect page in the identity mapping. This can lead to a crash due to a read from non-existing physical memory.