### PR TITLE
Enable SMEP

### DIFF
--- a/arch/x86/64/CMakeLists.include
+++ b/arch/x86/64/CMakeLists.include
@@ -60,8 +60,8 @@ add_custom_target(kvm
 
 # qemu: Run qemu in non debugging mode
 add_custom_target(qemu
-	COMMAND	${QEMU_BIN} ${QEMU_FLAGS_COMMON} -cpu qemu64 | tee output.log
-	COMMENT "Executing `${QEMU_BIN} ${QEMU_FLAGS_COMMON_STR} -cpu qemu64`"
+	COMMAND	${QEMU_BIN} ${QEMU_FLAGS_COMMON} -cpu qemu64,+smep | tee output.log
+	COMMENT "Executing `${QEMU_BIN} ${QEMU_FLAGS_COMMON_STR} -cpu qemu64,+smep`"
 	WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
 	COMMAND reset -I
 	)

--- a/arch/x86/64/source/ArchCommon.cpp
+++ b/arch/x86/64/source/ArchCommon.cpp
@@ -247,7 +247,7 @@ extern "C" void entry64()
   asm volatile("mov $7, %%rax\n"
                "xor %%rcx, %%rcx\n"
                "cpuid\n"
-               :"=b"(ebx)::"rax", "rcx", "rdx", "cc");
+               :"=b"(ebx)::"rax", "rcx", "rdx");
   if (ebx & (1<<7))
   {
     PRINT("Enable SMEP...\n");

--- a/arch/x86/64/source/boot.32.C
+++ b/arch/x86/64/source/boot.32.C
@@ -105,33 +105,33 @@ extern "C" void entry()
 
   PRINT("Initializing Kernel Paging Structures...\n");
   asm volatile("movl $kernel_page_directory_pointer_table - BASE + 3, kernel_page_map_level_4 - BASE\n"
-      "movl $0, kernel_page_map_level_4 - BASE + 4\n");
+      "movl $0, kernel_page_map_level_4 - BASE + 4\n" ::: "memory");
   asm volatile("movl $kernel_page_directory - BASE + 3, kernel_page_directory_pointer_table - BASE\n"
-      "movl $0, kernel_page_directory_pointer_table - BASE + 4\n");
+      "movl $0, kernel_page_directory_pointer_table - BASE + 4\n" ::: "memory");
   asm volatile("movl $0x83, kernel_page_directory - BASE\n"
-      "movl $0, kernel_page_directory - BASE + 4\n");
+      "movl $0, kernel_page_directory - BASE + 4\n" ::: "memory");
 
-  PRINT("Enable PSE and PAE...\n");
-  asm volatile("mov %cr4,%eax\n"
-      "or $0x20, %eax\n"
-      "mov %eax,%cr4\n");
+  PRINT("Enable PAE...\n");
+  asm volatile("mov %%cr4,%%eax\n"
+      "or $0x20, %%eax\n"
+      "mov %%eax,%%cr4\n" ::: "eax");
 
   PRINT("Setting CR3 Register...\n");
   asm volatile("mov %[pd],%%cr3" : : [pd]"r"(TRUNCATE(kernel_page_map_level_4)));
 
   PRINT("Enable EFER.LME and EFER.NXE...\n");
-  asm volatile("mov $0xC0000080,%ecx\n"
+  asm volatile("mov $0xC0000080,%%ecx\n"
       "rdmsr\n"
-      "or $0x900,%eax\n"
-      "wrmsr\n");
+      "or $0x900,%%eax\n"
+      "wrmsr\n" ::: "ecx", "eax", "edx");
 
   asm volatile("push $2\n"
-      "popf\n");
+      "popf\n" ::: "cc");
 
   PRINT("Enable Paging...\n");
-  asm volatile("mov %cr0,%eax\n"
-      "or $0x80010001,%eax\n"
-      "mov %eax,%cr0\n");
+  asm volatile("mov %%cr0,%%eax\n"
+      "or $0x80010001,%%eax\n"
+      "mov %%eax,%%cr0\n" ::: "eax", "memory");
 
   PRINT("Setup TSS...\n");
   TSS* g_tss_p = (TSS*) TRUNCATE(&g_tss);
@@ -162,7 +162,7 @@ extern "C" void entry()
       "mov %%ax, %%ss\n"
       "mov %%ax, %%fs\n"
       "mov %%ax, %%gs\n"
-      : : "a"(KERNEL_DS));
+      : : "a"(KERNEL_DS) : "memory");
 
   PRINT("Calling entry64()...\n");
   asm volatile("ljmp %[cs],$entry64-BASE\n" : : [cs]"i"(KERNEL_CS));

--- a/arch/x86/64/source/boot.32.C
+++ b/arch/x86/64/source/boot.32.C
@@ -126,7 +126,7 @@ extern "C" void entry()
       "wrmsr\n" ::: "ecx", "eax", "edx");
 
   asm volatile("push $2\n"
-      "popf\n" ::: "cc");
+      "popf\n");
 
   PRINT("Enable Paging...\n");
   asm volatile("mov %%cr0,%%eax\n"


### PR DESCRIPTION
Enable SMEP on x86_64 if it is available.
Add some clobbers to the boot code assembly.