### PR TITLE
fix compiler error in gcc 14

### DIFF
--- a/utils/add-debug/elf/data.hh
+++ b/utils/add-debug/elf/data.hh
@@ -544,7 +544,7 @@ struct Sym<Elf64, Order>
                 return (stb)(info >> 4);
         }
 
-        void set_binding(stb v) const
+        void set_binding(stb v)
         {
                 info = (info & 0xF) | ((unsigned char)v << 4);
         }


### PR DESCRIPTION
`set_binding` is declared as a const member function when it changes the member variable `this->info`. 

```cpp
 void set_binding(stb v) const
 {
     info = (info & 0xF) | ((unsigned char)v << 4);
 }
```

As the struct is a template it compiled pre-gcc14,  now gcc14+ is capable of throwing an error in this case too:

```cpp
// Detected by gcc 14
template<typename T>
class A {
    int b;
    void set() const {
        this->b = 1;
    }
};

// Detected by gcc 13 and gcc 14
class B {
    int b;
    void set() const {
        this->b = 1;
    }
};
```

https://godbolt.org/z/qW5j7WoaK

```
[ecomaikgolf@laptop ~/sweb/]$ git rev-parse --short HEAD
4f2a6230
[ecomaikgolf@laptop ~/sweb/]$ git status --porcelain    
?? build/
[ecomaikgolf@laptop ~/sweb/]$ make -C build 
make: Entering directory '/home/ecomaikgolf/sweb/build'

....

In file included from /home/ecomaikgolf/sweb/build/utils/add-debug/elf/to_string.cc:4:
/home/ecomaikgolf/sweb/utils/add-debug/elf/data.hh: In member function ‘void elf::Sym<elf::Elf64, Order>::set_binding(elf::stb) const’:
/home/ecomaikgolf/sweb/utils/add-debug/elf/data.hh:549:22: error: assignment of member ‘elf::Sym<elf::Elf64, Order>::info’ in read-only object
  549 |                 info = (info & 0xF) | ((unsigned char)v << 4);
      |                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [utils/add-debug/elf/CMakeFiles/elf++.dir/build.make:110: utils/add-debug/elf/CMakeFiles/elf++.dir/to_string.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /home/ecomaikgolf/sweb/utils/add-debug/elf/elf++.hh:5,
                 from /home/ecomaikgolf/sweb/utils/add-debug/elf/mmap_loader.cc:1:
/home/ecomaikgolf/sweb/utils/add-debug/elf/data.hh: In member function ‘void elf::Sym<elf::Elf64, Order>::set_binding(elf::stb) const’:
/home/ecomaikgolf/sweb/utils/add-debug/elf/data.hh:549:22: error: assignment of member ‘elf::Sym<elf::Elf64, Order>::info’ in read-only object
  549 |                 info = (info & 0xF) | ((unsigned char)v << 4);
      |                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [utils/add-debug/elf/CMakeFiles/elf++.dir/build.make:96: utils/add-debug/elf/CMakeFiles/elf++.dir/mmap_loader.cc.o] Error 1
In file included from /home/ecomaikgolf/sweb/utils/add-debug/elf/elf++.hh:5,
                 from /home/ecomaikgolf/sweb/utils/add-debug/elf/elf.cc:1:
/home/ecomaikgolf/sweb/utils/add-debug/elf/data.hh: In member function ‘void elf::Sym<elf::Elf64, Order>::set_binding(elf::stb) const’:
/home/ecomaikgolf/sweb/utils/add-debug/elf/data.hh:549:22: error: assignment of member ‘elf::Sym<elf::Elf64, Order>::info’ in read-only object
  549 |                 info = (info & 0xF) | ((unsigned char)v << 4);
      |                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [utils/add-debug/elf/CMakeFiles/elf++.dir/build.make:82: utils/add-debug/elf/CMakeFiles/elf++.dir/elf.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1684: utils/add-debug/elf/CMakeFiles/elf++.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
make: Leaving directory '/home/ecomaikgolf/sweb/build'
[ecomaikgolf@laptop ~/sweb/]$ gcc -v
Using built-in specs.
COLLECT_GCC=/usr/bin/gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/14/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none:amdgcn-amdhsa
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-redhat-linux
Configured with: ../configure --enable-bootstrap --enable-languages=c,c++,fortran,objc,obj-c++,ada,go,d,m2,lto --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-shared --enable-threads=posix --enable-checking=release --enable-multilib --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-gcc-major-version-only --enable-libstdcxx-backtrace --with-libstdcxx-zoneinfo=/usr/share/zoneinfo --with-linker-hash-style=gnu --enable-plugin --enable-initfini-array --with-isl=/builddir/build/BUILD/gcc-14.0.1-20240411/obj-x86_64-redhat-linux/isl-install --enable-offload-targets=nvptx-none,amdgcn-amdhsa --enable-offload-defaulted --without-cuda-driver --enable-gnu-indirect-function --enable-cet --with-tune=generic --with-arch_32=i686 --build=x86_64-redhat-linux --with-build-config=bootstrap-lto --enable-link-serialization=1
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 14.0.1 20240411 (Red Hat 14.0.1-0) (GCC) 
[ecomaikgolf@laptop ~/sweb/]$ 
```