### PR TITLE
Add shift keymap

### DIFF
--- a/arch/arm/integratorcp/source/KeyboardManager.cpp
+++ b/arch/arm/integratorcp/source/KeyboardManager.cpp
@@ -6,6 +6,8 @@ uint32 const KeyboardManager::STANDARD_KEYMAP[KEY_MAPPING_SIZE] = STANDARD_KEYMA
 
 uint32 const KeyboardManager::E0_KEYS[KEY_MAPPING_SIZE] = E0_KEYS_DEF;
 
+uint32 const KeyboardManager::SHIFT_KEYS[KEY_MAPPING_SIZE] = SHIFT_KEYS_DEF;
+
 uint8 const KeyboardManager::SET1_SCANCODES[KEY_MAPPING_SIZE + 1] = {127, 67, 0, 63, 61, 59, 60, 88, 100, 68, 66, 64, 62, 15, 41, 0, 101,
                                                  56, 42, 0, 29, 16,
                                                  2, 0, 102, 0, 44, 31, 30, 17, 3, 91, 103, 46, 45, 32, 18, 5, 4, 92,
@@ -188,9 +190,8 @@ void KeyboardManager::setLEDs(void)
 
 uint32 KeyboardManager::convertScancode(uint8 scancode)
 {
-  uint32 simple_key = STANDARD_KEYMAP[scancode] & 0xFF;
-  uint32 control_key = STANDARD_KEYMAP[scancode] & 0xFF00;
+  if (isShift() ^ isCaps())
+    return SHIFT_KEYS[scancode];
 
-  uint32 key = control_key | simple_key;
-  return key;
+  return STANDARD_KEYMAP[scancode];
 }

--- a/arch/common/include/KeyboardManager.h
+++ b/arch/common/include/KeyboardManager.h
@@ -31,6 +31,24 @@ extern "C"
                               0, 0, 0, 0, 0, 0, 0, 0, \
                             }
 
+#define SHIFT_KEYS_DEF { 0, 0x1B, ')', '!', '@', '#', '$' , '%', \
+                        '^', '*', '(', ')', '_', '+', '\b', '\t', \
+                        'Q', 'E', 'E', 'R', 'T', 'Y', 'U', 'I', \
+                        'O', 'P', '{', '}', '\n', KBD_META_CTRL, 'A', 'S', \
+                        'D', 'F', 'G', 'H', 'J', 'K', 'L', ':', \
+                        '"', '~', KBD_META_SHIFT, '|', 'Z', 'X', 'C', 'V', \
+                        'B', 'N', 'M', '<', '>', '?',KBD_META_SHIFT, '*', \
+                        KBD_META_LALT, ' ', KBD_META_CAPS, KEY_F1, KEY_F2, KEY_F3, KEY_F4, KEY_F5, \
+                        KEY_F6, KEY_F7, KEY_F8, KEY_F9, KEY_F10, KBD_META_NUM, KBD_META_SCRL, '7', \
+                        '8', '9', '-', '4', '5', '6', '+', '1', \
+                        '2', '3', '0', '.', 0, 0, 0, KEY_F11  , \
+                        KEY_F12, 0, 0, 0, 0, 0, 0, 0, \
+                        0, '\n', KBD_META_CTRL, '/', KEY_PRNT, KBD_META_RALT, 0, KEY_HOME, \
+                        KEY_UP, KEY_PGUP, KEY_LFT, KEY_RT, KEY_END, KEY_DN, KEY_PGDN, KEY_INS, \
+                        0, 0, 0, 0, 0, 0, 0, 0, \
+                        0, 0, 0, 0, 0, 0, 0, 0, \
+                      }
+
 #define E0_KEYS_DEF { 0, 0, 0, 0, 0, 0, 0, 0, \
                       0, 0, 0, 0, 0, 0, 0, 0, \
                       0, 0, 0, 0, 0, 0, 0, 0, \
@@ -194,6 +212,7 @@ class KeyboardManager
     RingBuffer<uint8> keyboard_buffer_;
 
     static uint32 const STANDARD_KEYMAP[];
+    static uint32 const SHIFT_KEYS[];
     static uint32 const E0_KEYS[];
     static uint8 const SET1_SCANCODES[];
     /**

--- a/arch/x86/common/source/KeyboardManager.cpp
+++ b/arch/x86/common/source/KeyboardManager.cpp
@@ -5,6 +5,8 @@
 
 uint32 const KeyboardManager::STANDARD_KEYMAP[KEY_MAPPING_SIZE] = STANDARD_KEYMAP_DEF;
 
+uint32 const KeyboardManager::SHIFT_KEYS[KEY_MAPPING_SIZE] = SHIFT_KEYS_DEF;
+
 uint32 const KeyboardManager::E0_KEYS[KEY_MAPPING_SIZE] = E0_KEYS_DEF;
 
 KeyboardManager *KeyboardManager::instance_ = 0;
@@ -172,9 +174,8 @@ void KeyboardManager::setLEDs(void)
 
 uint32 KeyboardManager::convertScancode(uint8 scancode)
 {
-  uint32 simple_key = STANDARD_KEYMAP[scancode] & 0xFF;
-  uint32 control_key = STANDARD_KEYMAP[scancode] & 0xFF00;
+  if (isShift() ^ isCaps())
+    return SHIFT_KEYS[scancode];
 
-  uint32 key = control_key | simple_key;
-  return key;
+  return STANDARD_KEYMAP[scancode];
 }

--- a/common/include/console/Terminal.h
+++ b/common/include/console/Terminal.h
@@ -98,15 +98,6 @@ class Terminal : public CharacterDevice
 
     void backspace();
 
-    /**
-     * Remaps the key if shift or capslock is active
-     * @param key the key to remap
-     * @return the remaped key
-     */
-    uint32 remap(uint32 key);
-
-    void setLayout(Terminal::LAYOUTS layout);
-
     bool isLockFree()
     {
       return mutex_.isFree();
@@ -131,9 +122,6 @@ class Terminal : public CharacterDevice
 
     uint32 setCharacter(uint32 row, uint32 column, uint8 character);
     void scrollUp();
-
-    bool isLetter(uint32 key);
-    bool isNumber(uint32 key);
 
     void clearScreen();
     void fullRedraw();

--- a/common/source/console/Console.cpp
+++ b/common/source/console/Console.cpp
@@ -109,7 +109,6 @@ void Console::Run(void)
     {
       if (isDisplayable(key))
       {
-        key = terminals_[active_terminal_]->remap(key);
         terminals_[active_terminal_]->write(key);
         terminals_[active_terminal_]->putInBuffer(key);
       }

--- a/common/source/console/Terminal.cpp
+++ b/common/source/console/Terminal.cpp
@@ -234,37 +234,3 @@ void Terminal::unSetAsActiveTerminal()
   ScopeLock lock(mutex_);
   active_ = 0;
 }
-
-bool Terminal::isLetter(uint32 key)
-{
-  return ((key >= 'a') && (key <= 'z'));
-}
-
-bool Terminal::isNumber(uint32 key)
-{
-  return ((key >= '0') && (key <= '9'));
-}
-
-uint32 Terminal::remap(uint32 key)
-{
-  uint32 number_table[] =
-  {
-  ')', '!', '@', '#', '$', '%', '^', '&', '*', '('
-  };
-
-  KeyboardManager * km = KeyboardManager::instance();
-
-  if (isLetter(key))
-  {
-    bool shifted = km->isShift() ^ km->isCaps();
-
-    if (shifted)
-      key &= ~0x20;
-  }
-  if (isNumber(key))
-  {
-    if (km->isShift())
-      key = number_table[key - '0'];
-  }
-  return key;
-}


### PR DESCRIPTION
Using underscores in test names is pretty common.
 
Now that sweb has tab completion, you can select tests with underscores in their name without having to type them.
Which lead to groups being confused why the tortillas test runner cannot run their tests.

So I thought it would be good to make underscores typeable by default.

Instead of remapping the keys with `Terminal::remap`, this introduces a shift map based on the US layout.
So other characters like `:"|<>?+` are also typeable.

If this is not desirable, I would propose to just add underscores to the remap function like [this](https://github.com/PaideiaDilemma/tortillas-sweb/commit/f39b7edb406764026622f555927b08e84db0e3fc).

Idk about the rpi2 and rpi3 implementations, their E0 map is weird, so I did not even touch that.
This will break shift for them.