### PR TITLE
Fixed `Superblock` naming inconsistency

### DIFF
--- a/common/include/fs/Inode.h
+++ b/common/include/fs/Inode.h
@@ -246,7 +246,7 @@ class Inode
       return superblock_;
     }
 
-    void setSuperBlock(Superblock * sb)
+    void setSuperblock(Superblock * sb)
     {
       superblock_ = sb;
     }

--- a/common/include/fs/devicefs/DeviceFSSuperblock.h
+++ b/common/include/fs/devicefs/DeviceFSSuperblock.h
@@ -8,13 +8,13 @@ class Superblock;
 class CharacterDevice;
 class DeviceFSType;
 
-class DeviceFSSuperBlock : public RamFSSuperblock
+class DeviceFSSuperblock : public RamFSSuperblock
 {
   public:
     static const char ROOT_NAME[];
     static const char DEVICE_ROOT_NAME[];
 
-    virtual ~DeviceFSSuperBlock();
+    virtual ~DeviceFSSuperblock();
 
     /**
      * addsa new device to the superblock
@@ -26,7 +26,7 @@ class DeviceFSSuperBlock : public RamFSSuperblock
     /**
      * Access method to the singleton instance
      */
-    static DeviceFSSuperBlock* getInstance();
+    static DeviceFSSuperblock* getInstance();
 
   private:
 
@@ -35,10 +35,10 @@ class DeviceFSSuperBlock : public RamFSSuperblock
      * @param s_root the root Dentry of the new Filesystem
      * @param s_dev the device number of the new Filesystem
      */
-    DeviceFSSuperBlock(DeviceFSType* fs_type, uint32 s_dev);
+    DeviceFSSuperblock(DeviceFSType* fs_type, uint32 s_dev);
 
   protected:
-    static DeviceFSSuperBlock* instance_;
+    static DeviceFSSuperblock* instance_;
 
 };
 

--- a/common/source/fs/devicefs/DeviceFSSuperblock.cpp
+++ b/common/source/fs/devicefs/DeviceFSSuperblock.cpp
@@ -14,24 +14,24 @@ class DeviceFSType;
 
 extern Console* main_console;
 
-const char DeviceFSSuperBlock::ROOT_NAME[] = "/";
-const char DeviceFSSuperBlock::DEVICE_ROOT_NAME[] = "dev";
+const char DeviceFSSuperblock::ROOT_NAME[] = "/";
+const char DeviceFSSuperblock::DEVICE_ROOT_NAME[] = "dev";
 
-DeviceFSSuperBlock* DeviceFSSuperBlock::instance_ = 0;
+DeviceFSSuperblock* DeviceFSSuperblock::instance_ = 0;
 
-DeviceFSSuperBlock::DeviceFSSuperBlock(DeviceFSType* fs_type, uint32 s_dev) :
+DeviceFSSuperblock::DeviceFSSuperblock(DeviceFSType* fs_type, uint32 s_dev) :
     RamFSSuperblock(fs_type, s_dev)
 {
 }
 
-DeviceFSSuperBlock::~DeviceFSSuperBlock()
+DeviceFSSuperblock::~DeviceFSSuperblock()
 {
 }
 
-void DeviceFSSuperBlock::addDevice(Inode* device_inode, const char* node_name)
+void DeviceFSSuperblock::addDevice(Inode* device_inode, const char* node_name)
 {
   // Devices are mounted at the devicefs root (s_root_)
-  device_inode->setSuperBlock(this);
+  device_inode->setSuperblock(this);
 
   Dentry* fdntr = new Dentry(device_inode, s_root_, node_name);
 
@@ -39,9 +39,9 @@ void DeviceFSSuperBlock::addDevice(Inode* device_inode, const char* node_name)
   all_inodes_.push_back(device_inode);
 }
 
-DeviceFSSuperBlock* DeviceFSSuperBlock::getInstance()
+DeviceFSSuperblock* DeviceFSSuperblock::getInstance()
 {
     if (!instance_)
-        instance_ = new DeviceFSSuperBlock(DeviceFSType::getInstance(), 0);
+        instance_ = new DeviceFSSuperblock(DeviceFSType::getInstance(), 0);
     return instance_;
 }

--- a/common/source/fs/devicefs/DeviceFSType.cpp
+++ b/common/source/fs/devicefs/DeviceFSType.cpp
@@ -20,7 +20,7 @@ Superblock* DeviceFSType::readSuper(Superblock *superblock, void*) const
 
 Superblock* DeviceFSType::createSuper(uint32 __attribute__((unused)) s_dev)
 {
-  Superblock *super = DeviceFSSuperBlock::getInstance();
+  Superblock *super = DeviceFSSuperblock::getInstance();
   return super;
 }
 


### PR DESCRIPTION
Most occurrences of Superblock are already written with a lowercase b (including the filename).
Now all Superblocks are written with lowercase b.