### PR TITLE
Implement basic C++ support for userspace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,11 @@ set(ENV{LIBRARY_NAMES})
 
 #Create target for userspace libc (Need to to that here because some files (e.g. syscall.c) are all over the place)
 add_library(userspace_libc "")
-target_compile_options(userspace_libc PUBLIC ${ARCH_USERSPACE_COMPILE_OPTIONS})
+target_compile_options(userspace_libc PRIVATE ${ARCH_USERSPACE_COMPILE_OPTIONS_C})
+
+#Do the same for userspace libcpp
+add_library(userspace_libcpp "")
+target_compile_options(userspace_libcpp PRIVATE ${ARCH_USERSPACE_COMPILE_OPTIONS_CXX})
 
 #Add the source directories
 add_subdirectory(arch)

--- a/arch/arm/integratorcp/CMakeLists.userspace
+++ b/arch/arm/integratorcp/CMakeLists.userspace
@@ -5,5 +5,6 @@ find_program(CMAKE_C_COMPILER arm-none-eabi-gcc)
 
 set(ARCH_APPEND_LD_ARGUMENTS -Wl,-no-whole-archive -Wl,-lgcc)
 
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gdwarf-4 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
+set(ARCH_USERSPACE_COMPILE_OPTIONS_C -Wall -Werror -std=gnu11 -gdwarf-4 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
+set(ARCH_USERSPACE_COMPILE_OPTIONS_CXX -Wall -Werror -std=gnu11 -gdwarf-4 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Wno-error=unused-variable -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)

--- a/arch/arm/rpi2/CMakeLists.userspace
+++ b/arch/arm/rpi2/CMakeLists.userspace
@@ -5,5 +5,6 @@ find_program(CMAKE_C_COMPILER arm-none-eabi-gcc)
 
 set(ARCH_APPEND_LD_ARGUMENTS -Wl,-no-whole-archive -Wl,-lgcc)
 
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gdwarf-4 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
+set(ARCH_USERSPACE_COMPILE_OPTIONS_C -Wall -Werror -std=gnu11 -gdwarf-4 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
+set(ARCH_USERSPACE_COMPILE_OPTIONS_CXX -Wall -Werror -std=gnu++11 -gdwarf-4 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Wno-error=unused-variable -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)

--- a/arch/armv8/common/userspace/CMakeLists.txt
+++ b/arch/armv8/common/userspace/CMakeLists.txt
@@ -3,3 +3,9 @@ FILE(GLOB userspace_libc_SOURCES ${CMAKE_CURRENT_LIST_DIR}/*.c)
 target_sources(userspace_libc
   PRIVATE
     ${userspace_libc_SOURCES})
+
+FILE(GLOB userspace_libcpp_SOURCES ${CMAKE_CURRENT_LIST_DIR}/*.cpp)
+
+target_sources(userspace_libcpp
+  PRIVATE
+    ${userspace_libcpp_SOURCES})

--- a/arch/armv8/rpi3/CMakeLists.userspace
+++ b/arch/armv8/rpi3/CMakeLists.userspace
@@ -5,5 +5,6 @@ find_program(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
 
 set(ARCH_APPEND_LD_ARGUMENTS -Wl,-no-whole-archive -Wl,-lgcc)
 
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror  -std=gnu11 -gdwarf-4 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
+set(ARCH_USERSPACE_COMPILE_OPTIONS_C -Wall -Werror  -std=gnu11 -gdwarf-4 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
+set(ARCH_USERSPACE_COMPILE_OPTIONS_CXX -Wall -Werror  -std=gnu++11 -gdwarf-4 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Wno-error=unused-variable -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)

--- a/arch/x86/32/CMakeLists.userspace
+++ b/arch/x86/32/CMakeLists.userspace
@@ -1,2 +1,3 @@
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gdwarf-4 -O0 -m32 -static -nostdinc -fno-builtin -nostdlib -nodefaultlibs -fno-stack-protector -fno-common -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection -mno-sse2 -mno-sse3)
+set(ARCH_USERSPACE_COMPILE_OPTIONS_C -Wall -Werror -std=gnu11 -gdwarf-4 -O0 -m32 -static -nostdinc -fno-builtin -nostdlib -nodefaultlibs -fno-stack-protector -fno-common -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection -mno-sse2 -mno-sse3)
+set(ARCH_USERSPACE_COMPILE_OPTIONS_CXX -Wall -Werror -std=gnu++11 -gdwarf-4 -fno-omit-frame-pointer -O0 -m32 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Wno-error=unused-variable -fno-stack-clash-protection -mno-sse2 -fcheck-new)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static -Wl,--section-start=.note.gnu.property=0x0A000000)

--- a/arch/x86/32/common/userspace/CMakeLists.txt
+++ b/arch/x86/32/common/userspace/CMakeLists.txt
@@ -3,3 +3,9 @@ FILE(GLOB userspace_libc_SOURCES ${CMAKE_CURRENT_LIST_DIR}/*.c)
 target_sources(userspace_libc
   PRIVATE
     ${userspace_libc_SOURCES})
+
+FILE(GLOB userspace_libcpp_SOURCES ${CMAKE_CURRENT_LIST_DIR}/*.cpp)
+
+target_sources(userspace_libcpp
+  PRIVATE
+    ${userspace_libcpp_SOURCES})

--- a/arch/x86/32/pae/CMakeLists.userspace
+++ b/arch/x86/32/pae/CMakeLists.userspace
@@ -1,2 +1,3 @@
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gdwarf-4 -O0 -m32 -static -nostdinc -fno-builtin -nostdlib -nodefaultlibs -fno-stack-protector -fno-common -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection -mno-sse2 -mno-sse3)
+set(ARCH_USERSPACE_COMPILE_OPTIONS_C -Wall -Werror -std=gnu11 -gdwarf-4 -O0 -m32 -static -nostdinc -fno-builtin -nostdlib -nodefaultlibs -fno-stack-protector -fno-common -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection -mno-sse2 -mno-sse3)
+set(ARCH_USERSPACE_COMPILE_OPTIONS_CXX -Wall -Werror -std=gnu++11 -gdwarf-4 -fno-omit-frame-pointer -O0 -m32 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Wno-error=unused-variable -fno-stack-clash-protection -fcheck-new)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static -Wl,--section-start=.note.gnu.property=0x0A000000)

--- a/arch/x86/64/CMakeLists.userspace
+++ b/arch/x86/64/CMakeLists.userspace
@@ -1,2 +1,3 @@
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gdwarf-4 -O0 -m64 -static -nostdinc -fno-builtin -nostdlib -nodefaultlibs -fno-stack-protector -fno-common -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
+set(ARCH_USERSPACE_COMPILE_OPTIONS_C -Wall -Werror -std=gnu11 -g -gdwarf-4 -O0 -m64 -static -nostdinc -fno-builtin -nostdlib -nodefaultlibs -fno-stack-protector -fno-common -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
+set(ARCH_USERSPACE_COMPILE_OPTIONS_CXX -Wall -Werror -std=gnu++11 -g -gdwarf-4 -O0 -m64 -static -nostdinc -fno-builtin -nostdlib -nodefaultlibs -fno-stack-protector -fno-common -Wno-error=unused-variable -fno-stack-clash-protection -fcheck-new)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)

--- a/arch/x86/64/userspace/CMakeLists.txt
+++ b/arch/x86/64/userspace/CMakeLists.txt
@@ -3,3 +3,9 @@ FILE(GLOB userspace_libc_SOURCES ${CMAKE_CURRENT_LIST_DIR}/*.c)
 target_sources(userspace_libc
   PRIVATE
     ${userspace_libc_SOURCES})
+
+FILE(GLOB userspace_libcpp_SOURCES ${CMAKE_CURRENT_LIST_DIR}/*.cpp)
+
+target_sources(userspace_libcpp
+  PRIVATE
+    ${userspace_libcpp_SOURCES})

--- a/userspace/CMakeLists.txt
+++ b/userspace/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(libc)
+add_subdirectory(libcpp)
 add_subdirectory(tests)

--- a/userspace/libcpp/CMakeLists.txt
+++ b/userspace/libcpp/CMakeLists.txt
@@ -1,0 +1,6 @@
+target_include_directories(userspace_libcpp
+  PUBLIC
+    include
+)
+
+add_subdirectory(src)

--- a/userspace/libcpp/include/stddef.h
+++ b/userspace/libcpp/include/stddef.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace std
+{
+  typedef __SIZE_TYPE__ size_t;
+  typedef decltype(nullptr) nullptr_t;
+}

--- a/userspace/libcpp/src/CMakeLists.txt
+++ b/userspace/libcpp/src/CMakeLists.txt
@@ -1,9 +1,3 @@
-FILE(GLOB userspace_libc_SOURCES ${CMAKE_CURRENT_LIST_DIR}/*.c)
-
-target_sources(userspace_libc
-  PRIVATE
-    ${userspace_libc_SOURCES})
-
 FILE(GLOB userspace_libcpp_SOURCES ${CMAKE_CURRENT_LIST_DIR}/*.cpp)
 
 target_sources(userspace_libcpp

--- a/userspace/libcpp/src/new.cpp
+++ b/userspace/libcpp/src/new.cpp
@@ -1,0 +1,21 @@
+#include "stddef.h"
+
+void *operator new(std::size_t size)
+{
+  return nullptr;
+}
+
+void operator delete(void *ptr)
+{
+  return;
+}
+
+void *operator new[](std::size_t size)
+{
+  return nullptr;
+}
+
+void operator delete[](void *ptr)
+{
+  return;
+}

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(userspace_tests)
+project(userspace_tests LANGUAGES C CXX)
 include(../../arch/${ARCH}/CMakeLists.userspace)
 
 # Put userspace libraries and executables in seperated paths
@@ -11,7 +11,8 @@ set($ENV{USERSPACE_NAMES} "")
 set(USERSPACE_TESTS_COMPILE_OPTIONS)
 set(USERSPACE_TESTS_LINKER_OPTIONS -Wl,-Ttext=0x8000000 -Wl,--build-id=none -Wl,-whole-archive)
 
-set(FINAL_USERSPACE_TESTS_COMPILE_OPTIONS ${ARCH_USERSPACE_COMPILE_OPTIONS} ${USERSPACE_TESTS_COMPILE_OPTIONS})
+set(FINAL_USERSPACE_TESTS_COMPILE_OPTIONS_C ${ARCH_USERSPACE_COMPILE_OPTIONS_C} ${USERSPACE_TESTS_COMPILE_OPTIONS})
+set(FINAL_USERSPACE_TESTS_COMPILE_OPTIONS_CXX ${ARCH_USERSPACE_COMPILE_OPTIONS_CXX} ${USERSPACE_TEST_COMPILE_OPTIONS})
 set(FINAL_USERSPACE_TESTS_LINKER_OPTIONS ${ARCH_LD_ARGUMENTS} ${ARCH_USERSPACE_LINKER_OPTIONS} ${USERSPACE_TESTS_LINKER_OPTIONS})
 
 file(GLOB userspace_tests_SOURCES ${SOURCE_WILDCARDS})
@@ -19,9 +20,20 @@ file(GLOB userspace_tests_SOURCES ${SOURCE_WILDCARDS})
 # Create own executable for every .c file and link with libc
 foreach(curFile ${userspace_tests_SOURCES})
   get_filename_component(curName ${curFile} NAME_WE)
+  get_filename_component(curExt ${curFile} EXT)
 
   add_executable(${curName}.sweb ${curFile})
+
+  target_compile_options(${curName}.sweb PRIVATE
+    $<$<COMPILE_LANGUAGE:C>:${FINAL_USERSPACE_TESTS_COMPILE_OPTIONS_C}>
+    $<$<COMPILE_LANGUAGE:CXX>:${FINAL_USERSPACE_TESTS_COMPILE_OPTIONS_CXX}>
+  )
+
   target_link_libraries(${curName}.sweb ${FINAL_USERSPACE_TESTS_LINKER_OPTIONS} userspace_libc ${ARCH_APPEND_LD_ARGUMENTS})
+
+  if(curExt STREQUAL ".cpp")
+    target_link_libraries(${curName}.sweb userspace_libcpp)
+  endif()
 
   ADD_DEBUG_INFO(${curName}.sweb)
 

--- a/userspace/tests/cpp-test.cpp
+++ b/userspace/tests/cpp-test.cpp
@@ -1,0 +1,31 @@
+#include "stdio.h"
+#include "stdlib.h"
+
+class TestClass
+{
+private:
+
+  int num_;
+
+public:
+
+  TestClass() = default;
+  TestClass(int num) : num_(num) {}
+  
+  void helloWorld()
+  {
+    printf("Hello world with num %d\n", num_);
+  }
+};
+
+int main()
+{
+  TestClass test(123);
+
+  test.helloWorld();
+
+  TestClass *test_p = new TestClass();
+  printf("%p\n", test_p);
+
+  exit(0);
+}


### PR DESCRIPTION
These changes allow for userspace tests written in C++. These tests can include and use any header in userspace/libc, as well as in the newly created userspace/libcpp. Standard C++ features like throw do not (yet) work, as they depend on ABI support functions like __cxa_throw, which are not implemented.
The changes do, however, add overload stubs for new, new[], delete, and delete[]. These can be implemented once SWEB supports the heap and functions like malloc.
Note: There is still room for improvement when including libc headers anywhere in userspace/libcpp. Currently, relative include paths must be used.