### PR TITLE
Add SSE support to x86_64

### DIFF
--- a/arch/x86/64/include/ArchThreads.h
+++ b/arch/x86/64/include/ArchThreads.h
@@ -11,33 +11,34 @@
 
 struct ArchThreadRegisters
 {
-  uint64  rip;       //   0
-  uint64  cs;        //   8
-  uint64  rflags;    //  16
-  uint64  rax;       //  24
-  uint64  rcx;       //  32
-  uint64  rdx;       //  40
-  uint64  rbx;       //  48
-  uint64  rsp;       //  56
-  uint64  rbp;       //  64
-  uint64  rsi;       //  72
-  uint64  rdi;       //  80
-  uint64  r8;        //  88
-  uint64  r9;        //  96
-  uint64  r10;       // 104
-  uint64  r11;       // 112
-  uint64  r12;       // 120
-  uint64  r13;       // 128
-  uint64  r14;       // 136
-  uint64  r15;       // 144
-  uint64  ds;        // 152
-  uint64  es;        // 160
-  uint64  fs;        // 168
-  uint64  gs;        // 176
-  uint64  ss;        // 184
-  uint64  rsp0;      // 192
-  uint64  cr3;       // 200
-  uint32  fpu[28];   // 208
+  uint64  rip;           //   0
+  uint64  cs;            //   8
+  uint64  rflags;        //  16
+  uint64  rax;           //  24
+  uint64  rcx;           //  32
+  uint64  rdx;           //  40
+  uint64  rbx;           //  48
+  uint64  rsp;           //  56
+  uint64  rbp;           //  64
+  uint64  rsi;           //  72
+  uint64  rdi;           //  80
+  uint64  r8;            //  88
+  uint64  r9;            //  96
+  uint64  r10;           // 104
+  uint64  r11;           // 112
+  uint64  r12;           // 120
+  uint64  r13;           // 128
+  uint64  r14;           // 136
+  uint64  r15;           // 144
+  uint64  ds;            // 152
+  uint64  es;            // 160
+  uint64  fs;            // 168
+  uint64  gs;            // 176
+  uint64  ss;            // 184
+  uint64  rsp0;          // 192
+  uint64  cr3;           // 200
+  uint8  *fpu = nullptr; // 208
+  ~ArchThreadRegisters() {delete[] fpu;}
 };
 
 class Thread;

--- a/arch/x86/64/source/ArchCommon.cpp
+++ b/arch/x86/64/source/ArchCommon.cpp
@@ -229,8 +229,6 @@ struct GDTPtr
     uint64 addr;
 }__attribute__((__packed__)) gdt_ptr;
 
-
-
 extern "C" void entry64()
 {
   PRINT("Parsing Multiboot Header...\n");

--- a/arch/x86/64/source/ArchThreads.cpp
+++ b/arch/x86/64/source/ArchThreads.cpp
@@ -17,10 +17,7 @@ void ArchThreads::initialise()
   asm volatile ("movq %%cr0, %%rax\n"
           "and $0xFFFB, %%ax\n"
           "or $0x2, %%ax\n"
-          "movq %%rax, %%cr0\n"
-          "movq %%cr4, %%rax\n"
-          "orq $0x200, %%rax\n"
-          "movq %%rax, %%cr4\n" : : : "rax");
+          "movq %%rax, %%cr0\n": : : "rax", "memory");
 }
 void ArchThreads::setAddressSpace(Thread *thread, ArchMemory& arch_memory)
 {
@@ -46,15 +43,6 @@ void ArchThreads::createBaseThreadRegisters(ArchThreadRegisters *&info, void* st
   info->rsp     = (size_t)stack;
   info->rbp     = (size_t)stack;
   info->rip     = (size_t)start_function;
-
-  /* fpu (=fninit) */
-  info->fpu[0] = 0xFFFF037F;
-  info->fpu[1] = 0xFFFF0000;
-  info->fpu[2] = 0xFFFFFFFF;
-  info->fpu[3] = 0x00000000;
-  info->fpu[4] = 0x00000000;
-  info->fpu[5] = 0x00000000;
-  info->fpu[6] = 0xFFFF0000;
 }
 
 void ArchThreads::createKernelRegisters(ArchThreadRegisters *&info, void* start_function, void* kernel_stack)
@@ -77,6 +65,7 @@ void ArchThreads::createUserRegisters(ArchThreadRegisters *&info, void* start_fu
   info->es      = USER_DS;
   info->ss      = USER_SS;
   info->rsp0    = (size_t)kernel_stack;
+  info->fpu = new uint8[512]{};
   assert(info->cr3);
 }
 

--- a/arch/x86/64/source/arch_interrupts.S
+++ b/arch/x86/64/source/arch_interrupts.S
@@ -1,5 +1,5 @@
 # ok, this is our main interrupt handling stuff
-
+.section .note.GNU-stack,"",@progbits
 .code64
 .text
 

--- a/common/include/mm/KernelMemoryManager.h
+++ b/common/include/mm/KernelMemoryManager.h
@@ -66,6 +66,7 @@ class MallocSegment
 
   private:
     size_t size_flag_; // = 0; //max size is 2^31-1
+    char padding_[8];
 };
 
 extern void* kernel_end_address;
@@ -169,3 +170,5 @@ class KernelMemoryManager
     uint32 segments_free_;
     size_t approx_memory_free_;
 };
+
+static_assert(0 == (sizeof(MallocSegment) & 0xf) && "malloc segment is not a multiple of 16 bytes, this will break alignment");

--- a/common/source/mm/KernelMemoryManager.cpp
+++ b/common/source/mm/KernelMemoryManager.cpp
@@ -61,6 +61,7 @@ pointer KernelMemoryManager::allocateMemory(size_t requested_size, pointer calle
     unlockKMM();
 
   debug(KMM, "allocateMemory returns address: %zx \n", ptr);
+  assert(0 == (ptr & 0xf) && "kmalloc pointer is not 16-byte aligned, our heap is broken");
   return ptr;
 }
 pointer KernelMemoryManager::private_AllocateMemory(size_t requested_size, pointer called_by)


### PR DESCRIPTION
SSE is required to fully support the System-V calling convention. Now we finally have a proper context switch for the user-space SSE state.
This also fixes an alignment bug in the KMM and a new warning regarding ASM files on gcc.